### PR TITLE
Fix "Show() cannot be called twice"

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -37,6 +37,7 @@ public class PreferencesFxDialog extends DialogPane {
   private StorageHandler storageHandler;
   private boolean persistWindowState;
   private boolean saveSettings;
+  private boolean modalityInitialized;
   private ButtonType closeWindowBtnType = ButtonType.CLOSE;
   private ButtonType cancelBtnType = ButtonType.CANCEL;
   private ButtonType okBtnType = ButtonType.OK;
@@ -80,11 +81,17 @@ public class PreferencesFxDialog extends DialogPane {
    *              the {@link PreferencesFxDialog}, as long as it is open.
    */
   public void show(boolean modal) {
+    if (!modalityInitialized) {
+      // only set modality once to avoid exception:
+      // java.lang.IllegalStateException: Cannot set modality once stage has been set visible
+      Modality modality = modal ? Modality.APPLICATION_MODAL : Modality.NONE;
+      dialog.initModality(modality);
+      modalityInitialized = true;
+    }
+
     if (modal) {
-      dialog.initModality(Modality.APPLICATION_MODAL);
       dialog.showAndWait();
     } else {
-      dialog.initModality(Modality.NONE);
       dialog.show();
     }
   }


### PR DESCRIPTION
Fix #80 

When opening a dialog for the second time, with the modality being initialized already, an exception will be thrown in certain cases.
Previously, this fix was only applied to the Java 11 branch, but since this issue appeared also with Java 8, we'll apply it there as well.

## Breaking Change:
It's not possible to change the modality, once the dialog has been opened. However, this is not a behavior that's likely being used anyways, and is questionable whether this even worked in the past.