### PR TITLE
explicitly set file encoding to prevent maven warning

### DIFF
--- a/preferencesfx/pom.xml
+++ b/preferencesfx/pom.xml
@@ -59,6 +59,7 @@
 
     <properties>
         <checkstyle.path>../config/checkstyle/checkstyle.xml</checkstyle.path>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>


### PR DESCRIPTION
Maven is issuing the following warnings when running `mvn clean test`

```
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```

This PR sets the encoding explicitly to UTF-8 to make the build independent of the default encoding (windows uses Cp1252 as default)