### PR TITLE
fix javadoc warnings and set failOnError and failOnWarning to true

### DIFF
--- a/preferencesfx/pom.xml
+++ b/preferencesfx/pom.xml
@@ -95,7 +95,8 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.1</version>
                 <configuration>
-                    <failOnError>false</failOnError>
+                    <failOnError>true</failOnError>
+                    <failOnWarnings>true</failOnWarnings>
                     <force>true</force>
                     <windowtitle>PreferencesFX API</windowtitle>
                     <additionalJOption>-J-Djavafx.javadoc=true

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
@@ -69,8 +69,9 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
    *   Objects.equals(x, deserialize(serialize(x), X.class)
    * </pre>
    *
+   * @param <T>        the type of object into which to deserialze the string
    * @param serialized the string to deserialze
-   * @param type the class into which to deserialize the string
+   * @param type       the class into which to deserialize the string
    * @return string representation of the object for storage
    */
   protected abstract <T> T deserialize(String serialized, Class<? extends T> type);
@@ -285,6 +286,7 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
    * to save / load as the key in {@link Preferences}, since those are guaranteed to be
    * maximum 64 chars long.
    *
+   * @param key the string for which to calculate the hash
    * @return SHA-256 representation of breadcrumb
    */
   public String hash(String key) {


### PR DESCRIPTION
Now all Javadoc comments are OK and the build can be configured to fail if new warnings/errors are introduced.

Feel free to reject this PR if you prefer not to be forced to follow exactly the Javadoc rules :wink: 