### PR TITLE
Support of enums for field values

### DIFF
--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/extended/ExtendedExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/extended/ExtendedExample.java
@@ -2,10 +2,12 @@ package com.dlsc.preferencesfx.demo.extended;
 
 import com.dlsc.formsfx.model.structure.Field;
 import com.dlsc.formsfx.model.structure.IntegerField;
+import com.dlsc.formsfx.model.structure.SingleSelectionField;
 import com.dlsc.formsfx.model.validators.DoubleRangeValidator;
 import com.dlsc.preferencesfx.PreferencesFx;
 import com.dlsc.preferencesfx.demo.AppStarter;
 import com.dlsc.preferencesfx.formsfx.view.controls.IntegerSliderControl;
+import com.dlsc.preferencesfx.formsfx.view.controls.SimpleComboBoxControl;
 import com.dlsc.preferencesfx.model.Category;
 import com.dlsc.preferencesfx.model.Group;
 import com.dlsc.preferencesfx.model.Setting;
@@ -71,6 +73,14 @@ public class ExtendedExample extends StackPane {
   // Custom Control
   IntegerProperty customControlProperty = new SimpleIntegerProperty(42);
   IntegerField customControl = setupCustomControl();
+
+  // Enum Control
+  private enum MyEnum {
+    FIRST, SECOND, THIRD
+  }
+  private ObjectProperty<MyEnum> myEnumSettingValue = new SimpleObjectProperty<>(MyEnum.FIRST);
+  private SingleSelectionField<MyEnum> myEnumControl =
+      Field.ofSingleSelectionType(Arrays.asList(MyEnum.values()), 0).render(new SimpleComboBoxControl<>());
 
   public ExtendedExample() {
     preferencesFx = createPreferences();
@@ -175,7 +185,7 @@ public class ExtendedExample extends StackPane {
                         Setting.of("Folder", directoryProperty, "Browse", null, true),
                         Setting.of("File with Default", fileDefaultProperty, new File("/"), false),
                         Setting.of("Folder with Default", directoryDefaultProperty, new File("/"), true)
-                        )
+                    )
                 )
             ),
         Category.of("Favorites",
@@ -278,7 +288,8 @@ public class ExtendedExample extends StackPane {
                         Category.of("Android SDK")
                     ),
                 Category.of("File Colors"),
-                Category.of("Scopes"),
+                Category.of("Scopes",
+                    Setting.of("My Enum", myEnumControl , myEnumSettingValue)),
                 Category.of("Notifications"),
                 Category.of("Quick Lists"),
                 Category.of("Path Variables")

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/extended/ExtendedExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/extended/ExtendedExample.java
@@ -79,8 +79,10 @@ public class ExtendedExample extends StackPane {
     FIRST, SECOND, THIRD
   }
   private ObjectProperty<MyEnum> myEnumSettingValue = new SimpleObjectProperty<>(MyEnum.FIRST);
+  private SimpleListProperty<MyEnum> enumList =
+      new SimpleListProperty<>(FXCollections.observableArrayList(Arrays.asList(MyEnum.values())));
   private SingleSelectionField<MyEnum> myEnumControl =
-      Field.ofSingleSelectionType(Arrays.asList(MyEnum.values()), 0).render(new SimpleComboBoxControl<>());
+      Field.ofSingleSelectionType(enumList, myEnumSettingValue).render(new SimpleComboBoxControl<>());
 
   public ExtendedExample() {
     preferencesFx = createPreferences();

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
@@ -15,8 +15,9 @@ import static com.dlsc.preferencesfx.util.Constants.WINDOW_WIDTH;
 import com.dlsc.preferencesfx.model.Setting;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import javafx.collections.FXCollections;
@@ -71,9 +72,27 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
    *
    * @param serialized the string to deserialze
    * @param type the class into which to deserialize the string
-   * @return string representation of the object for storage
+   * @return the deserialized object
    */
-  protected abstract <T> T deserialize(String serialized, Class<? extends T> type);
+  protected abstract <T> T deserialize(String serialized, Class<T> type);
+
+  /**
+   * Deserializes a list of objects from a string for storage.
+   *
+   * <p>Subclasses may use any way to deserialize the list.
+   * This should be the inverse operation of {@link #serialize(Object)}.
+   *
+   * <p>Therefore the following must hold true for any x of type List&lt;X&gt;:
+   * <pre>
+   *   Objects.equals(x, deserializeList(serialize(x), X.class)
+   * </pre>
+   *
+   * @param <T>        the type of objects in the list
+   * @param serialized the string to deserialze
+   * @param type       the class into which to deserialize the string
+   * @return deserialized list
+   */
+  protected abstract  <T> List<T> deserializeList(String serialized, Class<T> type);
   // asciidoctor Documentation - end::serializationDeserialization[]
 
 
@@ -226,10 +245,8 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
   }
 
   /**
-   * Searches in the preferences after a serialized ArrayList using the given key,
-   * deserializes and returns it as ObservableArrayList.
-   * When an ObservableList is deserialzed, Gson returns an ArrayList
-   * and needs to be wrapped into an ObservableArrayList. This is only needed for loading.
+   * Searches in the preferences after a serialized List using the given key,
+   * deserializes and returns it as ObservableList.
    *
    * @param breadcrumb            the key which is used to search the serialized ArrayList
    * @param defaultObservableList the default ObservableList
@@ -240,8 +257,43 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
       String breadcrumb,
       ObservableList defaultObservableList
   ) {
-    String serialized = getSerializedPreferencesValue(breadcrumb, serialize(defaultObservableList));
-    return FXCollections.observableArrayList(deserialize(serialized, ArrayList.class));
+    final String serializedDefault = serialize(defaultObservableList);
+    final String serialized = getSerializedPreferencesValue(breadcrumb, serializedDefault);
+    final Class<?> type = getTypeFromList(defaultObservableList);
+    return FXCollections.observableArrayList(deserializeList(serialized, type));
+  }
+
+  /**
+   * Searches in the storage after a serialized List using the given key, deserializes and
+   * returns it as ObservableList.
+   *
+   * @param <T>                   the type inside the list returned by this method
+   * @param <U>                   the type inside the the default list
+   * @param breadcrumb            the key which is used to search the serialized ArrayList
+   * @param defaultObservableList the default ObservableList which will be returned if nothing is
+   *                              found
+   * @return the deserialized ObservableList or the default ObservableList if nothing is found
+   */
+  public <T, U extends T> ObservableList<T> loadObservableList(
+      String breadcrumb,
+      Class<T> type,
+      ObservableList<U> defaultObservableList
+  ) {
+    final String serializedDefault = serialize(defaultObservableList);
+    final String serialized = getSerializedPreferencesValue(breadcrumb, serializedDefault);
+    return FXCollections.observableArrayList(deserializeList(serialized, type));
+  }
+
+  private Class<?> getTypeFromList(ObservableList<?> list) {
+    if (list == null) {
+      return Object.class;
+    }
+
+    final Optional<Class<?>> potentialClass = list.stream()
+        .filter(Objects::nonNull)
+        .findFirst()
+        .map(Object::getClass);
+    return potentialClass.orElse(Object.class);
   }
 
   private String getSerializedPreferencesValue(String breadcrumb, String serializedDefault) {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
@@ -205,7 +205,22 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
    */
   public Object loadObject(String breadcrumb, Object defaultObject) {
     String serialized = getSerializedPreferencesValue(breadcrumb, serialize(defaultObject));
-    return deserialize(serialized, Object.class);
+    final Class<?> type = defaultObject == null ? Object.class : defaultObject.getClass();
+    return deserialize(serialized, type);
+  }
+
+  /**
+   * Searches in the preferences after a serialized Object using the given key,
+   * deserializes and returns it. Returns a default Object if nothing is found.
+   *
+   * @param breadcrumb    the key which is used to search the serialized Object
+   * @param type          the type of object used for deserialization
+   * @param defaultObject the Object which will be returned if nothing is found
+   * @return the deserialized Object or the default Object if nothing is found
+   */
+  public <T> T loadObject(String breadcrumb, Class<T> type, T defaultObject) {
+    String serialized = getSerializedPreferencesValue(breadcrumb, serialize(defaultObject));
+    return deserialize(serialized, type);
   }
 
   /**

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
@@ -93,7 +93,7 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
    * @param type       the class into which to deserialize the string
    * @return deserialized list
    */
-  protected abstract  <T> List<T> deserializeList(String serialized, Class<T> type);
+  protected abstract <T> List<T> deserializeList(String serialized, Class<T> type);
   // asciidoctor Documentation - end::serializationDeserialization[]
 
 
@@ -234,13 +234,12 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
    * deserializes and returns it. Returns a default Object if nothing is found.
    *
    * @param <T>           the type of object returned by this method
-   * @param <U>           the type of the default object
    * @param breadcrumb    the key which is used to search the serialized Object
    * @param type          the type of object used for deserialization
    * @param defaultObject the Object which will be returned if nothing is found
    * @return the deserialized Object or the default Object if nothing is found
    */
-  public <T, U extends T> T loadObject(String breadcrumb, Class<T> type, U defaultObject) {
+  public <T> T loadObject(String breadcrumb, Class<T> type, T defaultObject) {
     String serialized = getSerializedPreferencesValue(breadcrumb, serialize(defaultObject));
     return deserialize(serialized, type);
   }
@@ -269,16 +268,15 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
    * returns it as ObservableList.
    *
    * @param <T>                   the type inside the list returned by this method
-   * @param <U>                   the type inside the the default list
    * @param breadcrumb            the key which is used to search the serialized ArrayList
    * @param defaultObservableList the default ObservableList which will be returned if nothing is
    *                              found
    * @return the deserialized ObservableList or the default ObservableList if nothing is found
    */
-  public <T, U extends T> ObservableList<T> loadObservableList(
+  public <T> ObservableList<T> loadObservableList(
       String breadcrumb,
       Class<T> type,
-      ObservableList<U> defaultObservableList
+      ObservableList<T> defaultObservableList
   ) {
     final String serializedDefault = serialize(defaultObservableList);
     final String serialized = getSerializedPreferencesValue(breadcrumb, serializedDefault);

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/PreferencesBasedStorageHandler.java
@@ -213,12 +213,14 @@ public abstract class PreferencesBasedStorageHandler implements StorageHandler {
    * Searches in the preferences after a serialized Object using the given key,
    * deserializes and returns it. Returns a default Object if nothing is found.
    *
+   * @param <T>           the type of object returned by this method
+   * @param <U>           the type of the default object
    * @param breadcrumb    the key which is used to search the serialized Object
    * @param type          the type of object used for deserialization
    * @param defaultObject the Object which will be returned if nothing is found
    * @return the deserialized Object or the default Object if nothing is found
    */
-  public <T> T loadObject(String breadcrumb, Class<T> type, T defaultObject) {
+  public <T, U extends T> T loadObject(String breadcrumb, Class<T> type, U defaultObject) {
     String serialized = getSerializedPreferencesValue(breadcrumb, serialize(defaultObject));
     return deserialize(serialized, type);
   }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
@@ -135,10 +135,8 @@ public interface StorageHandler {
   <T, U extends T> T loadObject(String breadcrumb, Class<T> type, U defaultObject);
 
   /**
-   * Searches in the storage after a serialized ArrayList using the given key, deserializes and
-   * returns it as ObservableArrayList. When an ObservableList is deserialzed, Gson returns an
-   * ArrayList and needs to be wrapped into an ObservableArrayList. This is only needed for
-   * loading.
+   * Searches in the storage after a serialized List using the given key, deserializes and
+   * returns it as ObservableList.
    *
    * @param breadcrumb            the key which is used to search the serialized ArrayList
    * @param defaultObservableList the default ObservableList which will be returned if nothing is
@@ -146,6 +144,24 @@ public interface StorageHandler {
    * @return the deserialized ObservableList or the default ObservableList if nothing is found
    */
   ObservableList loadObservableList(String breadcrumb, ObservableList defaultObservableList);
+
+  /**
+   * Searches in the storage after a serialized List using the given key, deserializes and
+   * returns it as ObservableList.
+   *
+   * @param <T>                   the type inside the list returned by this method
+   * @param <U>                   the type inside the the default list
+   * @param breadcrumb            the key which is used to search the serialized ArrayList
+   * @param type                  the of object used for deserialization the objects inside the list
+   * @param defaultObservableList the default ObservableList which will be returned if nothing is
+   *                              found
+   * @return the deserialized ObservableList or the default ObservableList if nothing is found
+   */
+  <T, U extends T> ObservableList<T> loadObservableList(
+      String breadcrumb,
+      Class<T> type,
+      ObservableList<U> defaultObservableList
+  );
 
   /**
    * Clears the storage.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
@@ -125,12 +125,14 @@ public interface StorageHandler {
    * Searches in the storage after a serialized Object using the given key, deserializes and returns
    * it. Returns a default Object if nothing is found.
    *
+   * @param <T>           the type of object returned by this method
+   * @param <U>           the type of the default object
    * @param breadcrumb    the key which is used to search the serialized Object
    * @param type          the type of object used for deserialization
    * @param defaultObject the Object which will be returned if nothing is found
    * @return the deserialized Object or the default Object if nothing is found
    */
-  <T> T loadObject(String breadcrumb, Class<T> type, T defaultObject);
+  <T, U extends T> T loadObject(String breadcrumb, Class<T> type, U defaultObject);
 
   /**
    * Searches in the storage after a serialized ArrayList using the given key, deserializes and

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
@@ -126,13 +126,12 @@ public interface StorageHandler {
    * it. Returns a default Object if nothing is found.
    *
    * @param <T>           the type of object returned by this method
-   * @param <U>           the type of the default object
    * @param breadcrumb    the key which is used to search the serialized Object
    * @param type          the type of object used for deserialization
    * @param defaultObject the Object which will be returned if nothing is found
    * @return the deserialized Object or the default Object if nothing is found
    */
-  <T, U extends T> T loadObject(String breadcrumb, Class<T> type, U defaultObject);
+  <T> T loadObject(String breadcrumb, Class<T> type, T defaultObject);
 
   /**
    * Searches in the storage after a serialized List using the given key, deserializes and
@@ -150,17 +149,16 @@ public interface StorageHandler {
    * returns it as ObservableList.
    *
    * @param <T>                   the type inside the list returned by this method
-   * @param <U>                   the type inside the the default list
    * @param breadcrumb            the key which is used to search the serialized ArrayList
    * @param type                  the of object used for deserialization the objects inside the list
    * @param defaultObservableList the default ObservableList which will be returned if nothing is
    *                              found
    * @return the deserialized ObservableList or the default ObservableList if nothing is found
    */
-  <T, U extends T> ObservableList<T> loadObservableList(
+  <T> ObservableList<T> loadObservableList(
       String breadcrumb,
       Class<T> type,
-      ObservableList<U> defaultObservableList
+      ObservableList<T> defaultObservableList
   );
 
   /**

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
@@ -122,6 +122,17 @@ public interface StorageHandler {
   // asciidoctor Documentation - end::storageHandlerLoad[]
 
   /**
+   * Searches in the storage after a serialized Object using the given key, deserializes and returns
+   * it. Returns a default Object if nothing is found.
+   *
+   * @param breadcrumb    the key which is used to search the serialized Object
+   * @param type          the type of object used for deserialization
+   * @param defaultObject the Object which will be returned if nothing is found
+   * @return the deserialized Object or the default Object if nothing is found
+   */
+  <T> T loadObject(String breadcrumb, Class<T> type, T defaultObject);
+
+  /**
    * Searches in the storage after a serialized ArrayList using the given key, deserializes and
    * returns it as ObservableArrayList. When an ObservableList is deserialzed, Gson returns an
    * ArrayList and needs to be wrapped into an ObservableArrayList. This is only needed for

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
@@ -3,6 +3,7 @@ package com.dlsc.preferencesfx.util;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,7 +38,7 @@ public class StorageHandlerImpl extends PreferencesBasedStorageHandler {
     final List<JsonElement> list = gson.fromJson(serialized, typeToken.getType());
 
     if (list == null) {
-      return null;
+      return Collections.emptyList();
     }
 
     return list.stream()

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandlerImpl.java
@@ -1,11 +1,13 @@
 package com.dlsc.preferencesfx.util;
 
-import com.dlsc.preferencesfx.model.Setting;
 import com.google.gson.Gson;
-import java.util.prefs.Preferences;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
- * Handles everything related to storing values of {@link Setting} using {@link Preferences}.
+ * Handles everything related to serializing and de-serializing values.
  *
  * @author François Martin
  * @author Marco Sanfratello
@@ -25,7 +27,21 @@ public class StorageHandlerImpl extends PreferencesBasedStorageHandler {
   }
 
   @Override
-  protected <T> T deserialize(String serialized, Class<? extends T> type) {
+  protected <T> T deserialize(String serialized, Class<T> type) {
     return gson.fromJson(serialized, type);
+  }
+
+  @Override
+  protected <T> List<T> deserializeList(String serialized, Class<T> type) {
+    final TypeToken typeToken = new TypeToken<List<JsonElement>>() {};
+    final List<JsonElement> list = gson.fromJson(serialized, typeToken.getType());
+
+    if (list == null) {
+      return null;
+    }
+
+    return list.stream()
+        .map(jsonElement -> gson.fromJson(jsonElement, type))
+        .collect(Collectors.toList());
   }
 }

--- a/preferencesfx/src/test/java/com/dlsc/preferencesfx/util/StorageHandlerImplTest.java
+++ b/preferencesfx/src/test/java/com/dlsc/preferencesfx/util/StorageHandlerImplTest.java
@@ -5,6 +5,9 @@ import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_HEIGHT;
 import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_POS_X;
 import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_POS_Y;
 import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_WIDTH;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static javafx.collections.FXCollections.observableList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -13,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.gson.internal.LinkedTreeMap;
 import java.util.Objects;
+import javafx.collections.ObservableList;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -217,6 +221,80 @@ public class StorageHandlerImplTest {
 
   @Test
   public void loadObservableList() {
+    final ObservableList emptyList = storageHandler.loadObservableList("foo", observableList(emptyList()));
+    assertThat(emptyList, is(observableList(emptyList())));
+
+    final ObservableList nullList = storageHandler.loadObservableList("foo", observableList(asList(null, null, null)));
+    assertThat(nullList, is(observableList(asList(null, null, null))));
+
+    final ObservableList stringList = storageHandler.loadObservableList("foo", observableList(asList("a", "b", "c")));
+    assertThat(stringList, is(observableList(asList("a", "b", "c"))));
+
+    final ObservableList intList = storageHandler.loadObservableList("foo", observableList(asList(1, 2, 3)));
+    assertThat(intList, is(observableList(asList(1, 2, 3))));
+
+    final ObservableList enumList = storageHandler.loadObservableList("foo", observableList(asList(TestEnum.FOO, TestEnum.BAR)));
+    assertThat(enumList, is(observableList(asList(TestEnum.FOO, TestEnum.BAR))));
+  }
+
+  @Test
+  public void saveAndLoadObservableList() {
+    storageHandler.saveObject("foo", asList("a", "b", "c"));
+    final ObservableList stringList = storageHandler.loadObservableList("foo", observableList(asList("x")));
+    assertThat(stringList, is(observableList(asList("a", "b", "c"))));
+
+    storageHandler.saveObject("foo", asList(1, 2, 3));
+    final ObservableList intList = storageHandler.loadObservableList("foo", observableList(asList(99)));
+    assertThat(intList, is(observableList(asList(1, 2, 3))));
+
+    storageHandler.saveObject("foo", asList(TestEnum.FOO, TestEnum.BAR));
+    final ObservableList enumList = storageHandler.loadObservableList("foo", observableList(asList(TestEnum.BAZ)));
+    assertThat(enumList, is(observableList(asList(TestEnum.FOO, TestEnum.BAR))));
+  }
+
+  @Test
+  public void saveAndLoadObservableListWithEmptyDefault() {
+    storageHandler.saveObject("foo", asList("a", "b", "c"));
+    final ObservableList stringList = storageHandler.loadObservableList("foo", observableList(emptyList()));
+    assertThat(stringList, is(observableList(asList("a", "b", "c"))));
+
+    storageHandler.saveObject("foo", asList(1, 2, 3));
+    final ObservableList intList = storageHandler.loadObservableList("foo", observableList(emptyList()));
+    assertThat(intList, is(observableList(asList(1.0, 2.0, 3.0))));
+
+    storageHandler.saveObject("foo", asList(TestEnum.FOO, TestEnum.BAR));
+    final ObservableList enumList = storageHandler.loadObservableList("foo", observableList(emptyList()));
+    assertThat(enumList, is(observableList(asList("FOO", "BAR"))));
+  }
+
+  @Test
+  public void saveAndLoadObservableListWithType() {
+    storageHandler.saveObject("foo", asList("a", "b", "c"));
+    final ObservableList stringList = storageHandler.loadObservableList("foo", String.class, observableList(asList("x")));
+    assertThat(stringList, is(observableList(asList("a", "b", "c"))));
+
+    storageHandler.saveObject("foo", asList(1, 2, 3));
+    final ObservableList intList = storageHandler.loadObservableList("foo", Integer.class, observableList(asList(99)));
+    assertThat(intList, is(observableList(asList(1, 2, 3))));
+
+    storageHandler.saveObject("foo", asList(TestEnum.FOO, TestEnum.BAR));
+    final ObservableList enumList = storageHandler.loadObservableList("foo", TestEnum.class, observableList(asList(TestEnum.BAZ)));
+    assertThat(enumList, is(observableList(asList(TestEnum.FOO, TestEnum.BAR))));
+  }
+
+  @Test
+  public void saveAndLoadObservableListWithTypeAndEmptyDefault() {
+    storageHandler.saveObject("foo", asList("a", "b", "c"));
+    final ObservableList stringList = storageHandler.loadObservableList("foo", String.class, observableList(emptyList()));
+    assertThat(stringList, is(observableList(asList("a", "b", "c"))));
+
+    storageHandler.saveObject("foo", asList(1, 2, 3));
+    final ObservableList intList = storageHandler.loadObservableList("foo", Integer.class, observableList(emptyList()));
+    assertThat(intList, is(observableList(asList(1, 2, 3))));
+
+    storageHandler.saveObject("foo", asList(TestEnum.FOO, TestEnum.BAR));
+    final ObservableList enumList = storageHandler.loadObservableList("foo", TestEnum.class, observableList(emptyList()));
+    assertThat(enumList, is(observableList(asList(TestEnum.FOO, TestEnum.BAR))));
   }
 
   @Test
@@ -227,7 +305,7 @@ public class StorageHandlerImplTest {
   }
 
   public enum TestEnum {
-    FOO, BAR
+    FOO, BAR, BAZ
   }
 
   public static class SomeObject {

--- a/preferencesfx/src/test/java/com/dlsc/preferencesfx/util/StorageHandlerImplTest.java
+++ b/preferencesfx/src/test/java/com/dlsc/preferencesfx/util/StorageHandlerImplTest.java
@@ -1,10 +1,16 @@
 package com.dlsc.preferencesfx.util;
 
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_DIVIDER_POSITION;
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_HEIGHT;
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_POS_X;
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_POS_Y;
+import static com.dlsc.preferencesfx.util.Constants.DEFAULT_PREFERENCES_WIDTH;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
-import java.util.prefs.BackingStoreException;
-import java.util.prefs.Preferences;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,75 +22,172 @@ import org.junit.Test;
  * @author Marco Sanfratello
  */
 public class StorageHandlerImplTest {
+
+  private StorageHandler storageHandler;
+
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
+    storageHandler = new StorageHandlerImpl(StorageHandlerImplTest.class);
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
+    storageHandler.clearPreferences();
   }
 
   @Test
-  public void testClearPreferences() throws BackingStoreException {
-    StorageHandler storageHandler = new StorageHandlerImpl(StorageHandlerImplTest.class);
-    Preferences preferences = storageHandler.getPreferences();
-    preferences.clear();
+  public void testClearPreferences() {
+    assertTrue(storageHandler.clearPreferences());
   }
 
   @Test
-  public void saveSelectedCategory() {
+  public void saveAndLoadSelectedCategory() {
+    final String initialCategory = storageHandler.loadSelectedCategory();
+    assertThat(initialCategory, is(nullValue()));
+
+    storageHandler.saveSelectedCategory("foo");
+    final String category = storageHandler.loadSelectedCategory();
+    assertThat(category, is("foo"));
   }
 
   @Test
-  public void loadSelectedCategory() {
+  public void saveAndLoadDividerPosition() {
+    final double initialDividerPosition = storageHandler.loadDividerPosition();
+    assertThat(initialDividerPosition, is(DEFAULT_DIVIDER_POSITION));
+
+    storageHandler.saveDividerPosition(2 * DEFAULT_DIVIDER_POSITION);
+    final double dividerPosition = storageHandler.loadDividerPosition();
+    assertThat(dividerPosition, is(2 * DEFAULT_DIVIDER_POSITION));
   }
 
   @Test
-  public void saveDividerPosition() {
+  public void saveAndLoadWindowWidth() {
+    final double initialWindowWidth = storageHandler.loadWindowWidth();
+    assertThat(initialWindowWidth, is((double) DEFAULT_PREFERENCES_WIDTH));
+
+    storageHandler.saveWindowWidth(2.0 * DEFAULT_PREFERENCES_WIDTH);
+    final double windowWidth = storageHandler.loadWindowWidth();
+    assertThat(windowWidth, is(2.0 * DEFAULT_PREFERENCES_WIDTH));
   }
 
   @Test
-  public void loadDividerPosition() {
+  public void saveAndLoadWindowHeight() {
+    final double initialWindowHeight = storageHandler.loadWindowHeight();
+    assertThat(initialWindowHeight, is((double) DEFAULT_PREFERENCES_HEIGHT));
+
+    storageHandler.saveWindowHeight(2.0 * DEFAULT_PREFERENCES_HEIGHT);
+    final double windowHeight = storageHandler.loadWindowHeight();
+    assertThat(windowHeight, is(2.0 * DEFAULT_PREFERENCES_HEIGHT));
   }
 
   @Test
-  public void saveWindowWidth() {
+  public void saveAndLoadWindowPosX() {
+    final double initialWindowPosX = storageHandler.loadWindowPosX();
+    assertThat(initialWindowPosX, is((double) DEFAULT_PREFERENCES_POS_X));
+
+    storageHandler.saveWindowPosX(2.0 * DEFAULT_PREFERENCES_POS_X);
+    final double windowPosX = storageHandler.loadWindowPosX();
+    assertThat(windowPosX, is(2.0 * DEFAULT_PREFERENCES_POS_X));
   }
 
   @Test
-  public void loadWindowWidth() {
+  public void saveAndLoadWindowPosY() {
+    final double initialWindowPosY = storageHandler.loadWindowPosY();
+    assertThat(initialWindowPosY, is((double) DEFAULT_PREFERENCES_POS_Y));
+
+    storageHandler.saveWindowPosY(2.0 * DEFAULT_PREFERENCES_POS_Y);
+    final double windowPosY = storageHandler.loadWindowPosY();
+    assertThat(windowPosY, is(2.0 * DEFAULT_PREFERENCES_POS_Y));
   }
 
   @Test
-  public void saveWindowHeight() {
+  public void loadDefaultObject() {
+    final Object defaultValue = storageHandler.loadObject("foo", null);
+    assertThat(defaultValue, is(nullValue()));
+
+    final Object defaultString = storageHandler.loadObject("foo", "bar");
+    assertThat(defaultString, is("bar"));
+    assertThat(defaultString, is(instanceOf(String.class)));
+
+    final Object defaultInt = storageHandler.loadObject("foo", 5);
+    assertThat(defaultInt, is(5));
+    assertThat(defaultInt, is(instanceOf(Integer.class)));
+
+    final Object defaultEnum = storageHandler.loadObject("foo", TestEnum.BAR);
+    assertThat(defaultEnum, is(TestEnum.BAR));
+    assertThat(defaultEnum, is(instanceOf(TestEnum.class)));
   }
 
   @Test
-  public void loadWindowHeight() {
+  public void saveAndLoadObject() {
+    storageHandler.saveObject("foo", "baz");
+    final Object loadedString = storageHandler.loadObject("foo", "bar");
+    assertThat(loadedString, is("baz"));
+    assertThat(loadedString, is(instanceOf(String.class)));
+
+    storageHandler.saveObject("foo", 10);
+    final Object loadedInt = storageHandler.loadObject("foo", 5);
+    assertThat(loadedInt, is(10));
+    assertThat(loadedInt, is(instanceOf(Integer.class)));
+
+    storageHandler.saveObject("foo", TestEnum.FOO);
+    final Object loadedEnum = storageHandler.loadObject("foo", TestEnum.BAR);
+    assertThat(loadedEnum, is(TestEnum.FOO));
+    assertThat(loadedEnum, is(instanceOf(TestEnum.class)));
   }
 
   @Test
-  public void saveWindowPosX() {
+  public void saveAndLoadObjectWithNullAsDefault() {
+    storageHandler.saveObject("foo", "baz");
+    final Object loadedString = storageHandler.loadObject("foo", null);
+    assertThat(loadedString, is("baz"));
+    assertThat(loadedString, is(instanceOf(String.class)));
+
+    storageHandler.saveObject("foo", 10);
+    final Object loadedInt = storageHandler.loadObject("foo", null);
+    assertThat(loadedInt, is(10.0));
+    assertThat(loadedInt, is(instanceOf(Double.class)));
+
+    storageHandler.saveObject("foo", TestEnum.FOO);
+    final Object loadedEnum = storageHandler.loadObject("foo", null);
+    assertThat(loadedEnum, is("FOO"));
+    assertThat(loadedEnum, is(instanceOf(String.class)));
   }
 
   @Test
-  public void loadWindowPosX() {
+  public void saveAndLoadObjectWithType() {
+    storageHandler.saveObject("foo", "baz");
+    final Object loadedString = storageHandler.loadObject("foo", String.class, "bar");
+    assertThat(loadedString, is("baz"));
+    assertThat(loadedString, is(instanceOf(String.class)));
+
+    storageHandler.saveObject("foo", 10);
+    final Object loadedInt = storageHandler.loadObject("foo", Integer.class, 5);
+    assertThat(loadedInt, is(10));
+    assertThat(loadedInt, is(instanceOf(Integer.class)));
+
+    storageHandler.saveObject("foo", TestEnum.FOO);
+    final Object loadedEnum = storageHandler.loadObject("foo", TestEnum.class, TestEnum.BAR);
+    assertThat(loadedEnum, is(TestEnum.FOO));
+    assertThat(loadedEnum, is(instanceOf(TestEnum.class)));
   }
 
   @Test
-  public void saveWindowPosY() {
-  }
+  public void saveAndLoadObjectWithTypeAndNullAsDefault() {
+    storageHandler.saveObject("foo", "baz");
+    final Object loadedString = storageHandler.loadObject("foo", String.class, null);
+    assertThat(loadedString, is("baz"));
+    assertThat(loadedString, is(instanceOf(String.class)));
 
-  @Test
-  public void loadWindowPosY() {
-  }
+    storageHandler.saveObject("foo", 10);
+    final Object loadedInt = storageHandler.loadObject("foo", Integer.class, null);
+    assertThat(loadedInt, is(10));
+    assertThat(loadedInt, is(instanceOf(Integer.class)));
 
-  @Test
-  public void saveObject() {
-  }
-
-  @Test
-  public void loadObject() {
+    storageHandler.saveObject("foo", TestEnum.FOO);
+    final Object loadedEnum = storageHandler.loadObject("foo", TestEnum.class, null);
+    assertThat(loadedEnum, is(TestEnum.FOO));
+    assertThat(loadedEnum, is(instanceOf(TestEnum.class)));
   }
 
   @Test
@@ -96,5 +199,9 @@ public class StorageHandlerImplTest {
     StorageHandlerImpl storageHandler = new StorageHandlerImpl(StorageHandlerImplTest.class);
     final String result = storageHandler.hash("test");
     assertThat(result, is("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"));
+  }
+
+  public enum TestEnum {
+    FOO, BAR
   }
 }

--- a/preferencesfx/src/test/java/com/dlsc/preferencesfx/util/StorageHandlerImplTest.java
+++ b/preferencesfx/src/test/java/com/dlsc/preferencesfx/util/StorageHandlerImplTest.java
@@ -11,6 +11,8 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.gson.internal.LinkedTreeMap;
+import java.util.Objects;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -116,6 +118,10 @@ public class StorageHandlerImplTest {
     final Object defaultEnum = storageHandler.loadObject("foo", TestEnum.BAR);
     assertThat(defaultEnum, is(TestEnum.BAR));
     assertThat(defaultEnum, is(instanceOf(TestEnum.class)));
+
+    final Object defaultObject = storageHandler.loadObject("foo", new SomeObject(5, "x"));
+    assertThat(defaultObject, is(new SomeObject(5, "x")));
+    assertThat(defaultObject, is(instanceOf(SomeObject.class)));
   }
 
   @Test
@@ -134,6 +140,11 @@ public class StorageHandlerImplTest {
     final Object loadedEnum = storageHandler.loadObject("foo", TestEnum.BAR);
     assertThat(loadedEnum, is(TestEnum.FOO));
     assertThat(loadedEnum, is(instanceOf(TestEnum.class)));
+
+    storageHandler.saveObject("foo", new SomeObject(6, "y"));
+    final Object defaultObject = storageHandler.loadObject("foo", new SomeObject(5, "x"));
+    assertThat(defaultObject, is(new SomeObject(6, "y")));
+    assertThat(defaultObject, is(instanceOf(SomeObject.class)));
   }
 
   @Test
@@ -152,6 +163,10 @@ public class StorageHandlerImplTest {
     final Object loadedEnum = storageHandler.loadObject("foo", null);
     assertThat(loadedEnum, is("FOO"));
     assertThat(loadedEnum, is(instanceOf(String.class)));
+
+    storageHandler.saveObject("foo", new SomeObject(6, "y"));
+    final Object defaultObject = storageHandler.loadObject("foo", null);
+    assertThat(defaultObject, is(instanceOf(LinkedTreeMap.class)));
   }
 
   @Test
@@ -170,6 +185,11 @@ public class StorageHandlerImplTest {
     final Object loadedEnum = storageHandler.loadObject("foo", TestEnum.class, TestEnum.BAR);
     assertThat(loadedEnum, is(TestEnum.FOO));
     assertThat(loadedEnum, is(instanceOf(TestEnum.class)));
+
+    storageHandler.saveObject("foo", new SomeObject(6, "y"));
+    final Object defaultObject = storageHandler.loadObject("foo", SomeObject.class, new SomeObject(5, "x"));
+    assertThat(defaultObject, is(new SomeObject(6, "y")));
+    assertThat(defaultObject, is(instanceOf(SomeObject.class)));
   }
 
   @Test
@@ -188,6 +208,11 @@ public class StorageHandlerImplTest {
     final Object loadedEnum = storageHandler.loadObject("foo", TestEnum.class, null);
     assertThat(loadedEnum, is(TestEnum.FOO));
     assertThat(loadedEnum, is(instanceOf(TestEnum.class)));
+
+    storageHandler.saveObject("foo", new SomeObject(6, "y"));
+    final Object defaultObject = storageHandler.loadObject("foo", SomeObject.class, null);
+    assertThat(defaultObject, is(new SomeObject(6, "y")));
+    assertThat(defaultObject, is(instanceOf(SomeObject.class)));
   }
 
   @Test
@@ -203,5 +228,29 @@ public class StorageHandlerImplTest {
 
   public enum TestEnum {
     FOO, BAR
+  }
+
+  public static class SomeObject {
+    final int foo;
+    final String bar;
+
+    SomeObject(int foo, String bar) {
+      this.foo = foo;
+      this.bar = bar;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SomeObject that = (SomeObject) o;
+      return foo == that.foo &&
+          bar.equals(that.bar);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(foo, bar);
+    }
   }
 }


### PR DESCRIPTION
fixes #10 

Change existing method `Object StorageHandler.loadObject(String, Object)` to:
 * guess the type from the default value passed.
 * fall back to `Object` if the default value is null.

Change existing method `Object StorageHandler.loadObservableList(String, ObservableList)` to:
 * guess the type from the values in the list.
 * fall back to `Object` if the list is empty or contains only null.

Add new method `<T, U extends T> T StorageHandler.loadObject(String, Class<T>, U)`
 * allows to explicitly specify which type to use during deserialization

Add new method `<T, U extends T> T StorageHandler.loadObservableList(String, Class<T>, ObservableList<U>)`
 * allows to explicitly specify which type to use during deserialization of the list elements

Add tests for most of the methods in StorageHandlerImpl


## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [x] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [x] Tests for the changes are included.

## What is the current behavior?
Integer are deserialized to Double
Float are deserialized to Double
Enums are deserialzed to String
Objects are deserialized to LinkedTreeMap

## What is the new behavior?
Enums, Integer, Float and Objects are deserialized to the proper type unless null is passed as the default value

Fixes/Implements/Closes #10.

## Breaking Change:
StorageHandler.loadObject and StorageHandler.loadObservableList will return different types for values other than String, Boolean or Double.
If this breaking change is undesired the existing methods can be reverted and only the new ones added. This would also fix #10 without breaking the existing behavior