### PR TITLE
Fix Issue #128 - Don't throw NPE if PreferencesFX is used as a node in a new window

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxPresenter.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxPresenter.java
@@ -49,11 +49,10 @@ public class PreferencesFxPresenter implements Presenter {
       LOGGER.trace("new Scene: " + newScene);
       if (newScene != null && newScene.getWindow() != null) {
         LOGGER.trace("addEventHandler on Window close request to save settings");
-        newScene.getWindow()
-            .addEventHandler(WindowEvent.WINDOW_CLOSE_REQUEST, event -> {
-              LOGGER.trace("saveSettings because of WINDOW_CLOSE_REQUEST");
-              model.saveSettings();
-            });
+        newScene.getWindow().addEventHandler(WindowEvent.WINDOW_CLOSE_REQUEST, event -> {
+          LOGGER.trace("saveSettings because of WINDOW_CLOSE_REQUEST");
+          model.saveSettings();
+        });
       }
     });
   }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxPresenter.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxPresenter.java
@@ -45,6 +45,11 @@ public class PreferencesFxPresenter implements Presenter {
   public void setupEventHandlers() {
     // As the scene is null here, listen to scene changes and make sure
     // that when the window is closed, the settings are saved beforehand.
+
+    // NOTE: this only applies to the main stage. When opening PreferencesFX as a Node in a new
+    // window, the implementor needs to take care that Settings are saved by themself!
+    // This is intentional by design to ensure that if the implementor wants to make their own
+    // PreferencesFX dialog to not override settings in case they are discarded.
     preferencesFxView.sceneProperty().addListener((observable, oldScene, newScene) -> {
       LOGGER.trace("new Scene: " + newScene);
       if (newScene != null && newScene.getWindow() != null) {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxPresenter.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxPresenter.java
@@ -47,7 +47,7 @@ public class PreferencesFxPresenter implements Presenter {
     // that when the window is closed, the settings are saved beforehand.
     preferencesFxView.sceneProperty().addListener((observable, oldScene, newScene) -> {
       LOGGER.trace("new Scene: " + newScene);
-      if (newScene != null) {
+      if (newScene != null && newScene.getWindow() != null) {
         LOGGER.trace("addEventHandler on Window close request to save settings");
         newScene.getWindow()
             .addEventHandler(WindowEvent.WINDOW_CLOSE_REQUEST, event -> {


### PR DESCRIPTION
<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [ ] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are changing, or link to a relevant issue. -->
When using PreferencesFX as a node in a new window, a `NullPointerException` is thrown.
## What is the new behavior?
<!-- Describe the changes -->
The event handler that gets attached to the main stage if PreferencesFX is used as a Node, to ensure settings are saved before the application gets closed only gets applied on the main stage and not to other stages that are opened in new windows. 

Fixes #128