### PR TITLE
Allow instant persistence to be set at runtime & hide undo / redo when no instant persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Method | Class | Description
 `.saveSettings` | `PreferencesFx` | Defines whether the changed settings in the Preferences window should be saved or not. Defaults to true.
 `.debugHistoryMode` | `PreferencesFx` | Makes it possible to enable or disable the keycombination to open a debug view of the list of all actions in the history (undo / redo). Pressing Ctrl + Shift + H (Windows) or CMD + Shift + H (Mac) opens a dialog with the undo / redo history, shown in a table. Defaults to false.
 `.buttonsVisibility` | `PreferencesFx` | Sets the visibility of the cancel and close buttons in the `PreferencesFxDialog`. Defaults to true.
-`.instantPersistent` | `PreferencesFx` | If set to true, it will instantly apply any changes that are being made in the `PreferencesFxDialog`. If set to false, it will only apply changes when the `Save` button is pressed. Defaults to true.
+`.instantPersistent` | `PreferencesFx` | If set to true, it will instantly apply any changes that are being made in the `PreferencesFxDialog`. If set to false, it will only apply changes when the `Save` / `Apply` / `OK` button is pressed. Due to a limitation in FormsFX, undo / redo cannot be used with instant persistence switched off! Defaults to true.
 `.i18n` | `PreferencesFx` | Sets the translation service of the preferences dialog for internationalization.
 `.dialogTitle` | `PreferencesFx` | Allows to specify a custom dialog title.
 `.dialogIcon` | `PreferencesFx` | Allows to specify a custom dialog icon.

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/standard/DemoView.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/standard/DemoView.java
@@ -81,8 +81,10 @@ public class DemoView extends VBox {
         favoritesLbl,
         fontSizeLbl,
         lineSpacingLbl,
-        favoriteNumberLbl
+        favoriteNumberLbl,
+        instantPersistence
     );
+    instantPersistence.setSelected(true);
     valueBox.setSpacing(20);
     valueBox.setPadding(new Insets(20, 0, 0, 20));
 
@@ -98,9 +100,8 @@ public class DemoView extends VBox {
         new Label("Font Size:"),
         new Label("Line Spacing:"),
         new Label("Favorite Number:"),
-        instantPersistence
+        new Label("Instant Persistence:")
     );
-    instantPersistence.setSelected(true);
     descriptionBox.setSpacing(20);
     descriptionBox.setPadding(new Insets(20, 0, 0, 20));
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/BreadCrumbPresenter.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/BreadCrumbPresenter.java
@@ -48,6 +48,19 @@ public class BreadCrumbPresenter implements Presenter {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void setupBindings() {
+    // hide undoRedoBox if instant persistence is turned off
+    // this is due to a limit in FormsFX, only allowing to get the changed user input as a String
+    // when instant persistence is turned off, while it is not persisted yet
+    // this prevents us from getting notified of any changes except for changes in string fields.
+    // design decision: to be consistent, don't offer undo / redo at all
+    breadCrumbView.undoRedoBox.visibleProperty().bind(model.instantPersistentProperty());
+  }
+
+  /**
    * Sets up the BreadcrumbBar depending on the displayed category.
    */
   public void setupBreadCrumbBar() {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/BreadCrumbView.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/BreadCrumbView.java
@@ -45,9 +45,9 @@ public class BreadCrumbView extends HBox implements View {
     if (!model.isOneCategoryLayout()) {
       getChildren().add(breadCrumbBar);
     }
-    getChildren().addAll(
-        undoRedoBox
-    );
+    if (model.isInstantPersistent()) {
+      getChildren().add(undoRedoBox);
+    }
   }
 
   /**

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/BreadCrumbView.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/BreadCrumbView.java
@@ -20,7 +20,7 @@ public class BreadCrumbView extends HBox implements View {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(BreadCrumbView.class.getName());
   private final PreferencesFxModel model;
-  private final UndoRedoBox undoRedoBox;
+  final UndoRedoBox undoRedoBox;
   TreeItem<Category> breadcrumbsItm;
   BreadCrumbBar<Category> breadCrumbBar = new BreadCrumbBar<>();
 
@@ -45,9 +45,9 @@ public class BreadCrumbView extends HBox implements View {
     if (!model.isOneCategoryLayout()) {
       getChildren().add(breadCrumbBar);
     }
-    if (model.isInstantPersistent()) {
-      getChildren().add(undoRedoBox);
-    }
+    getChildren().addAll(
+        undoRedoBox
+    );
   }
 
   /**

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/CategoryPresenter.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/CategoryPresenter.java
@@ -120,6 +120,7 @@ public class CategoryPresenter implements Presenter {
   }
 
   private void applyInstantPersistence(boolean instantPersistent, Form form) {
+    LOGGER.trace("Applying instant persistence: " + instantPersistent);
     BindingMode persistence;
     if (instantPersistent) {
       // instant persistence is on

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -116,6 +116,7 @@ public class PreferencesFxDialog extends DialogPane {
 
   private void addButtons() {
     LOGGER.trace("Add dialog buttons for instant persistence: " + model.isInstantPersistent());
+    getButtonTypes().clear();
     if (model.isInstantPersistent()) {
       getButtonTypes().addAll(closeWindowBtnType, cancelBtnType);
     } else {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -99,13 +99,17 @@ public class PreferencesFxDialog extends DialogPane {
   private void layoutForm() {
     dialog.setTitle("Preferences");
     dialog.setResizable(true);
+    addButtons();
+    dialog.setDialogPane(this);
+    setContent(preferencesFxView);
+  }
+
+  private void addButtons() {
     if (model.isInstantPersistent()) {
       getButtonTypes().addAll(closeWindowBtnType, cancelBtnType);
     } else {
       getButtonTypes().addAll(cancelBtnType, applyBtnType, okBtnType);
     }
-    dialog.setDialogPane(this);
-    setContent(preferencesFxView);
   }
 
   private void setupDialogClose() {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -174,6 +174,14 @@ public class PreferencesFxDialog extends DialogPane {
     final Button cancelBtn = (Button) lookupButton(cancelBtnType);
     final Button applyBtn = (Button) lookupButton(applyBtnType);
 
+    // make sure if visibleProperty was bound in a previous call to unbind it first
+    if (closeBtn != null) {
+      closeBtn.visibleProperty().unbind();
+    }
+    if (cancelBtn != null) {
+      cancelBtn.visibleProperty().unbind();
+    }
+
     if (model.isInstantPersistent()) {
       cancelBtn.visibleProperty().bind(model.buttonsVisibleProperty());
       closeBtn.visibleProperty().bind(model.buttonsVisibleProperty());

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -169,7 +169,7 @@ public class PreferencesFxDialog extends DialogPane {
   }
 
   private void setupButtons() {
-    LOGGER.trace("Setting Buttons up");
+    LOGGER.trace("Setting Buttons up with instant persistence: " + model.isInstantPersistent());
     final Button closeBtn = (Button) lookupButton(closeWindowBtnType);
     final Button cancelBtn = (Button) lookupButton(cancelBtnType);
     final Button applyBtn = (Button) lookupButton(applyBtnType);

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -6,6 +6,7 @@ import com.dlsc.preferencesfx.model.PreferencesFxModel;
 import com.dlsc.preferencesfx.util.Constants;
 import com.dlsc.preferencesfx.util.StorageHandler;
 import javafx.event.ActionEvent;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
@@ -42,6 +43,7 @@ public class PreferencesFxDialog extends DialogPane {
   private ButtonType cancelBtnType = ButtonType.CANCEL;
   private ButtonType okBtnType = ButtonType.OK;
   private ButtonType applyBtnType = ButtonType.APPLY;
+  private Button applyWithEventBtn;
 
   /**
    * Initializes the {@link DialogPane} which shows the PreferencesFX window.
@@ -176,10 +178,15 @@ public class PreferencesFxDialog extends DialogPane {
       cancelBtn.visibleProperty().bind(model.buttonsVisibleProperty());
       closeBtn.visibleProperty().bind(model.buttonsVisibleProperty());
     } else {
-      applyBtn.addEventFilter(ActionEvent.ACTION, event -> {
-        event.consume();
-        model.saveSettings();
-      });
+      // check if we already added an event filter to the apply button, to avoid adding it twice
+      if (applyBtn != applyWithEventBtn) {
+        applyBtn.addEventFilter(ActionEvent.ACTION, event -> {
+          event.consume();
+          model.saveSettings();
+        });
+
+        applyWithEventBtn = applyBtn;
+      }
     }
   }
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -208,8 +208,16 @@ public class PreferencesFxDialog extends DialogPane {
   }
 
   private void bindButtonVisibility(Button closeBtn, Button cancelBtn) {
-    cancelBtn.visibleProperty().bind(model.buttonsVisibleProperty());
-    closeBtn.visibleProperty().bind(model.buttonsVisibleProperty());
+    if (closeBtn != null && cancelBtn != null) {
+      cancelBtn.visibleProperty().bind(model.buttonsVisibleProperty());
+      closeBtn.visibleProperty().bind(model.buttonsVisibleProperty());
+    } else {
+      LOGGER.error("Visibility of dialog buttons could not be set!"
+          + "Instant persistence is on, "
+          + "expected close (actual: {}) and cancel (actual: {}) buttons",
+          closeBtn, cancelBtn
+      );
+    }
   }
 
   private void unbindVisibility(Button closeBtn, Button cancelBtn) {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -189,12 +189,10 @@ public class PreferencesFxDialog extends DialogPane {
       // check if we already added an event filter to the apply button, to avoid adding it twice
       if (applyBtn != applyWithEventBtn) {
         LOGGER.trace("Adding event filter to apply button");
-        applyBtn.addEventFilter(
-            ActionEvent.ACTION,
-            event -> {
-              event.consume();
-              model.saveSettings();
-            });
+        applyBtn.addEventFilter(ActionEvent.ACTION, event -> {
+          event.consume();
+          model.saveSettings();
+        });
 
         applyWithEventBtn = applyBtn;
       } else {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -183,30 +183,42 @@ public class PreferencesFxDialog extends DialogPane {
     final Button cancelBtn = (Button) lookupButton(cancelBtnType);
     final Button applyBtn = (Button) lookupButton(applyBtnType);
 
+    unbindVisibility(closeBtn, cancelBtn);
+
+    if (model.isInstantPersistent()) {
+      bindButtonVisibility(closeBtn, cancelBtn);
+    } else {
+      addApplyEventFilterSaveSettings(applyBtn);
+    }
+  }
+
+  private void addApplyEventFilterSaveSettings(Button applyBtn) {
+    // check if we already added an event filter to the apply button, to avoid adding it twice
+    if (applyBtn != applyWithEventBtn) {
+      LOGGER.trace("Adding event filter to apply button");
+      applyBtn.addEventFilter(ActionEvent.ACTION, event -> {
+        event.consume();
+        model.saveSettings();
+      });
+
+      applyWithEventBtn = applyBtn;
+    } else {
+      LOGGER.trace("Event filter was already added previously to apply button");
+    }
+  }
+
+  private void bindButtonVisibility(Button closeBtn, Button cancelBtn) {
+    cancelBtn.visibleProperty().bind(model.buttonsVisibleProperty());
+    closeBtn.visibleProperty().bind(model.buttonsVisibleProperty());
+  }
+
+  private void unbindVisibility(Button closeBtn, Button cancelBtn) {
     // make sure if visibleProperty was bound in a previous call to unbind it first
     if (closeBtn != null) {
       closeBtn.visibleProperty().unbind();
     }
     if (cancelBtn != null) {
       cancelBtn.visibleProperty().unbind();
-    }
-
-    if (model.isInstantPersistent()) {
-      cancelBtn.visibleProperty().bind(model.buttonsVisibleProperty());
-      closeBtn.visibleProperty().bind(model.buttonsVisibleProperty());
-    } else {
-      // check if we already added an event filter to the apply button, to avoid adding it twice
-      if (applyBtn != applyWithEventBtn) {
-        LOGGER.trace("Adding event filter to apply button");
-        applyBtn.addEventFilter(ActionEvent.ACTION, event -> {
-          event.consume();
-          model.saveSettings();
-        });
-
-        applyWithEventBtn = applyBtn;
-      } else {
-        LOGGER.trace("Event filter was already added previously to apply button");
-      }
     }
   }
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -6,7 +6,6 @@ import com.dlsc.preferencesfx.model.PreferencesFxModel;
 import com.dlsc.preferencesfx.util.Constants;
 import com.dlsc.preferencesfx.util.StorageHandler;
 import javafx.event.ActionEvent;
-import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
@@ -188,14 +187,14 @@ public class PreferencesFxDialog extends DialogPane {
     if (model.isInstantPersistent()) {
       bindButtonVisibility(closeBtn, cancelBtn);
     } else {
-      addApplyEventFilterSaveSettings(applyBtn);
+      setupApplyBtn(applyBtn);
     }
   }
 
-  private void addApplyEventFilterSaveSettings(Button applyBtn) {
+  private void setupApplyBtn(Button applyBtn) {
     // check if we already added an event filter to the apply button, to avoid adding it twice
     if (applyBtn != applyWithEventBtn) {
-      LOGGER.trace("Adding event filter to apply button");
+      LOGGER.trace("Setting up apply button");
       applyBtn.addEventFilter(ActionEvent.ACTION, event -> {
         event.consume();
         model.saveSettings();

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -188,12 +188,17 @@ public class PreferencesFxDialog extends DialogPane {
     } else {
       // check if we already added an event filter to the apply button, to avoid adding it twice
       if (applyBtn != applyWithEventBtn) {
-        applyBtn.addEventFilter(ActionEvent.ACTION, event -> {
-          event.consume();
-          model.saveSettings();
-        });
+        LOGGER.trace("Adding event filter to apply button");
+        applyBtn.addEventFilter(
+            ActionEvent.ACTION,
+            event -> {
+              event.consume();
+              model.saveSettings();
+            });
 
         applyWithEventBtn = applyBtn;
+      } else {
+        LOGGER.trace("Event filter was already added previously to apply button");
       }
     }
   }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -105,6 +105,7 @@ public class PreferencesFxDialog extends DialogPane {
   }
 
   private void addButtons() {
+    LOGGER.trace("Add dialog buttons for instant persistence: " + model.isInstantPersistent());
     if (model.isInstantPersistent()) {
       getButtonTypes().addAll(closeWindowBtnType, cancelBtnType);
     } else {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -62,6 +62,7 @@ public class PreferencesFxDialog extends DialogPane {
     setupDialogClose();
     loadLastWindowState();
     setupButtons();
+    setupValueChangedListeners();
     if (model.getHistoryDebugState()) {
       setupDebugHistoryTable();
     }
@@ -104,6 +105,13 @@ public class PreferencesFxDialog extends DialogPane {
     addButtons();
     dialog.setDialogPane(this);
     setContent(preferencesFxView);
+  }
+
+  private void setupValueChangedListeners() {
+    model.instantPersistentProperty().addListener(observable -> {
+      addButtons();
+      setupButtons();
+    });
   }
 
   private void addButtons() {


### PR DESCRIPTION
<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [x] JavaDoc is added / changed for public methods.
- [x] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [x] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are changing, or link to a relevant issue. -->
Instant persistence of dialogs can only be set before initializing `PreferencesFx`. This means that for example the standard demo, which contains a checkbox to show the effects of instant persistence doesn't work.
Also, currently undo and redo buttons are shown, even if instant persistence is turned off. With instant persistence turned off, the `History` doesn't work anymore because of a limitation in FormsFX.
## What is the new behavior?
<!-- Describe the changes -->
Instant persistence of dialogs can now be set at any time. This means that for example the standard demo, which contains a checkbox to show the effects of instant persistence works again.
Undo and redo buttons are hidden when instant persistence is turned off