### PR TITLE
Custom Stylesheet for Dialog

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -310,6 +310,11 @@ public class PreferencesFx {
     return this;
   }
 
+  /**
+   * Return the stylesheets of the PreferenceFxDialog.
+   *
+   * @return the stylesheets List of the PreferenceFxDialog
+   */
   public ObservableList<String> getStylesheets(){
     return preferencesFxDialog.getStylesheets();
   }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -18,6 +18,7 @@ import com.dlsc.preferencesfx.view.PreferencesFxDialog;
 import com.dlsc.preferencesfx.view.PreferencesFxPresenter;
 import com.dlsc.preferencesfx.view.PreferencesFxView;
 import com.dlsc.preferencesfx.view.UndoRedoBox;
+import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.image.Image;
@@ -309,4 +310,7 @@ public class PreferencesFx {
     return this;
   }
 
+  public ObservableList<String> getStylesheets(){
+    return preferencesFxDialog.getStylesheets();
+  }
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -315,7 +315,7 @@ public class PreferencesFx {
    *
    * @return the stylesheets List of the PreferenceFxDialog
    */
-  public ObservableList<String> getStylesheets(){
+  public ObservableList<String> getStylesheets() {
     return preferencesFxDialog.getStylesheets();
   }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [x] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are changing, or link to a relevant issue. -->
Unable to set custom style sheet to dialog.

## What is the new behavior?
<!-- Describe the changes -->
I added a getStylesheet function to get the style sheet of the dialog. This allows users to add custom style sheets to the dialog.

Fixes/Resolves/Closes #11
