### PR TITLE
Added getStyleSheets Fucntion

### DIFF
--- a/preferencesfx/pom.xml
+++ b/preferencesfx/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.dlsc.preferencesfx</groupId>
     <artifactId>preferencesfx-core</artifactId>
-.    <version>11.8.0</version>
+    <version>11.8.0</version>
     <packaging>jar</packaging>
 
     <name>PreferencesFX</name>

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -18,6 +18,7 @@ import com.dlsc.preferencesfx.view.PreferencesFxDialog;
 import com.dlsc.preferencesfx.view.PreferencesFxPresenter;
 import com.dlsc.preferencesfx.view.PreferencesFxView;
 import com.dlsc.preferencesfx.view.UndoRedoBox;
+import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.image.Image;
@@ -308,5 +309,13 @@ public class PreferencesFx {
     preferencesFxDialog.setDialogIcon(image);
     return this;
   }
-
+  
+  /**
+   * Return the stylesheets of the PreferenceFxDialog.
+   *
+   * @return the stylesheets List of the PreferenceFxDialog
+   */
+  public ObservableList<String> getStylesheets() {
+    return preferencesFxDialog.getStylesheets();
+  }
 }


### PR DESCRIPTION
Adds the functionality to change the style of the preference window
This function already exists in the Java 8 version, this pull request adds the exact same code for Java 11.

<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [X] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [X] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are changing, or link to a relevant issue. -->
Unable to change stylesheet in Java 11 version

## What is the new behavior?
<!-- Describe the changes -->
Able to change stylesheet in Java 11 version
