### PR TITLE
Added SimplePasswordControl by porting it from FormsFX library.

### DIFF
--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/standard/StandardExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/standard/StandardExample.java
@@ -2,9 +2,11 @@ package com.dlsc.preferencesfx.demo.standard;
 
 import com.dlsc.formsfx.model.structure.Field;
 import com.dlsc.formsfx.model.structure.IntegerField;
+import com.dlsc.formsfx.model.structure.PasswordField;
 import com.dlsc.formsfx.model.validators.DoubleRangeValidator;
 import com.dlsc.preferencesfx.PreferencesFx;
 import com.dlsc.preferencesfx.formsfx.view.controls.IntegerSliderControl;
+import com.dlsc.preferencesfx.formsfx.view.controls.SimplePasswordControl;
 import com.dlsc.preferencesfx.model.Category;
 import com.dlsc.preferencesfx.model.Group;
 import com.dlsc.preferencesfx.model.Setting;
@@ -64,9 +66,13 @@ public class StandardExample extends StackPane {
           "Eboda Phot-O-Shop", "Mikesoft Text"))
   );
 
-  // Custom Control
+  // Custom Controls
   IntegerProperty customControlProperty = new SimpleIntegerProperty(42);
   IntegerField customControl = setupCustomControl();
+
+  StringProperty somePassword = new SimpleStringProperty("");
+  PasswordField somePasswordControl = Field.ofPasswordType(somePassword).render(
+        new SimplePasswordControl());
 
   public StandardExample() {
     preferencesFx = createPreferences();
@@ -88,6 +94,9 @@ public class StandardExample extends StackPane {
             Group.of("Display",
                 Setting.of("Brightness", brightness),
                 Setting.of("Night mode", nightMode)
+            ),
+            Group.of("Secrets",
+                    Setting.of("Password", somePasswordControl, somePassword)
             )
         ),
         Category.of("Screen")

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimplePasswordControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimplePasswordControl.java
@@ -1,0 +1,160 @@
+package com.dlsc.preferencesfx.formsfx.view.controls;
+
+/*-
+ * ========================LICENSE_START=================================
+ * FormsFX
+ * %%
+ * Copyright (C) 2017 DLSC Software & Consulting
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
+import com.dlsc.formsfx.model.structure.PasswordField;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.StringBinding;
+import javafx.geometry.Pos;
+import javafx.geometry.VPos;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.StackPane;
+
+/**
+ * This class provides the base implementation for a simple control to edit
+ * password values.
+ *
+ * @author Rinesch Murugathas
+ * @author Sacha Schmid
+ * @author Andres Almiray
+ */
+public class SimplePasswordControl extends SimpleControl<PasswordField, StackPane> {
+
+    /**
+     * - The fieldLabel is the container that displays the label property of
+     *   the field.
+     * - The editableField allows users to modify the field's value.
+     * - The readOnlyLabel displays the field's value if it is not editable.
+     */
+    protected javafx.scene.control.PasswordField editableField;
+    protected Label readOnlyLabel;
+    protected Label fieldLabel;
+
+    /*
+     * Translates characters found in user input into '*'
+     */
+    protected StringBinding obfuscatedUserInputBinding;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void initializeParts() {
+        super.initializeParts();
+
+        getStyleClass().add("simple-password-control");
+
+        this.node = new StackPane();
+
+        editableField = new javafx.scene.control.PasswordField();
+        editableField.setText(field.getValue());
+
+        readOnlyLabel = new Label(obfuscate(field.getValue()));
+        fieldLabel = new Label(field.labelProperty().getValue());
+        editableField.setPromptText(field.placeholderProperty().getValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void layoutParts() {
+        readOnlyLabel.getStyleClass().add("read-only-label");
+
+        readOnlyLabel.setPrefHeight(26);
+
+        this.node.getChildren().addAll(editableField, readOnlyLabel);
+
+        this.node.setAlignment(Pos.CENTER_LEFT);
+
+        Node labelDescription = field.getLabelDescription();
+        Node valueDescription = field.getValueDescription();
+
+        int columns = field.getSpan();
+
+        if (columns < 3) {
+            int rowIndex = 0;
+            add(fieldLabel, 0, rowIndex++, columns, 1);
+            if (labelDescription != null) {
+                GridPane.setValignment(labelDescription, VPos.TOP);
+                add(labelDescription, 0, rowIndex++, columns, 1);
+            }
+            add(this.node, 0, rowIndex++, columns, 1);
+            if (valueDescription != null) {
+                GridPane.setValignment(valueDescription, VPos.TOP);
+                add(valueDescription, 0, rowIndex, columns, 1);
+            }
+        } else {
+            add(fieldLabel, 0, 0, 2, 1);
+            if (labelDescription != null) {
+                GridPane.setValignment(labelDescription, VPos.TOP);
+                add(labelDescription, 0, 1, 2, 1);
+            }
+            add(this.node, 2, 0, columns - 2, 1);
+            if (valueDescription != null) {
+                GridPane.setValignment(valueDescription, VPos.TOP);
+                add(valueDescription, 2, 1, columns - 2, 1);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setupBindings() {
+        super.setupBindings();
+
+        editableField.visibleProperty().bind(field.editableProperty());
+        readOnlyLabel.visibleProperty().bind(field.editableProperty().not());
+
+        editableField.textProperty().bindBidirectional(field.userInputProperty());
+        obfuscatedUserInputBinding = Bindings.createStringBinding(() -> obfuscate(field.getUserInput()), field.userInputProperty());
+        readOnlyLabel.textProperty().bind(obfuscatedUserInputBinding);
+        fieldLabel.textProperty().bind(field.labelProperty());
+        editableField.promptTextProperty().bind(field.placeholderProperty());
+        editableField.managedProperty().bind(editableField.visibleProperty());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setupValueChangedListeners() {
+        super.setupValueChangedListeners();
+
+        field.errorMessagesProperty().addListener((observable, oldValue, newValue) -> toggleTooltip(editableField));
+
+        editableField.focusedProperty().addListener((observable, oldValue, newValue) -> toggleTooltip(editableField));
+    }
+
+    protected String obfuscate(String input) {
+        if (input == null) { return ""; }
+        int length = input.length();
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            b.append('*');
+        }
+        return b.toString();
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [ ] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [X] JavaDoc is added / changed for public methods.
- [x] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
PreferencesFx does not currently support password controls.

## What is the new behavior?
It does now. =)

Fixes #177