### PR TITLE
Make Setting constructor protected, so it's possible to extend this class

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Setting.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Setting.java
@@ -59,7 +59,7 @@ public class Setting<E extends Element, P extends Property> {
   private final StringProperty breadcrumb = new SimpleStringProperty("");
   private String key = "";
 
-  private Setting(String description, E element, P value) {
+  protected Setting(String description, E element, P value) {
     this.description = description;
     this.element = element;
     this.value = value;


### PR DESCRIPTION
It would be very useful to be able to extend this class so that custom `Setting.of()` implementations can be added.

## PR Checklist

- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [ ] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [ ] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
It is not possible to add new Setting.of functions.

## What is the new behavior?
Classes can extend the Setting class functionality.