### PR TITLE
Fix minor issues with new visibility functionality

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -75,6 +75,7 @@ public class PreferencesFx {
     breadCrumbPresenter = new BreadCrumbPresenter(preferencesFxModel, breadCrumbView);
 
     categoryController = new CategoryController();
+    categoryController.setFitToWidth(true);
     initializeCategoryViews();
 
     // display initial category

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleControl.java
@@ -84,6 +84,7 @@ public abstract class SimpleControl<F extends Field, N extends Node>
   @Override
   public void init() {
     this.initializeParts();
+    this.updatePseudoStyles();
     this.layoutParts();
     this.setupEventHandlers();
     this.setupValueChangedListeners();
@@ -100,6 +101,9 @@ public abstract class SimpleControl<F extends Field, N extends Node>
     fieldLabel = new Label();
     fieldLabel.getStyleClass().addAll(field.getStyleClass());
 
+  }
+
+  private void updatePseudoStyles() {
     updateStyle(INVALID_CLASS, !field.isValid());
     updateStyle(REQUIRED_CLASS, field.isRequired());
     updateStyle(CHANGED_CLASS, field.hasChanged());

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Group.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Group.java
@@ -185,7 +185,7 @@ public class Group {
   private void applyVisibilityForSettings() {
     if (settings != null) {
       for (Setting setting : settings) {
-        setting.applyVisibility(visibilityProperty);
+        setting.applyVisibility(visibilityProperty, true);
       }
     }
   }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Setting.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Setting.java
@@ -776,10 +776,23 @@ public class Setting<E extends Element, P extends Property> {
    * Apply {@link VisibilityProperty} to renderer ({@link SimpleControl}.
    *
    * @param visibilityProperty source visibility condition
+   * @param additionalVisibilityCondition define the visibility condition to be added (ANDed) to the current (if any)
    */
-  public void applyVisibility(VisibilityProperty visibilityProperty) {
+  public Setting applyVisibility(VisibilityProperty visibilityProperty, boolean additionalVisibilityCondition) {
     SimpleControl renderer = (SimpleControl) ((Field) getElement()).getRenderer();
 
+    if (additionalVisibilityCondition) {
+      VisibilityProperty existingVP = renderer.getVisibilityProperty();
+      if (existingVP != null) {
+        visibilityProperty = VisibilityProperty.of(existingVP.get().and(visibilityProperty.get()));
+      }
+    }
     renderer.setVisibilityProperty(visibilityProperty);
+    return this;
   }
+
+  public Setting applyVisibility(VisibilityProperty visibilityProperty) {
+    return applyVisibility(visibilityProperty, false);
+  }
+
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/VisibilityProperty.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/VisibilityProperty.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.value.ObservableValue;
 
 @FunctionalInterface
 public interface VisibilityProperty {
@@ -21,7 +22,7 @@ public interface VisibilityProperty {
      * @return
      * @param <T>
      */
-    static <T> VisibilityProperty of(Property<T> property, Function<T, Boolean> visibilityFunc) {
+    static <T> VisibilityProperty of(ObservableValue<T> property, Function<T, Boolean> visibilityFunc) {
         return () -> {
             BooleanProperty visibilityProperty = new SimpleBooleanProperty(true);
 
@@ -43,7 +44,7 @@ public interface VisibilityProperty {
      * @return
      * @param <T>
      */
-    static <T> VisibilityProperty of(Property<Boolean> property) {
+    static <T> VisibilityProperty of(ObservableValue<Boolean> property) {
         return VisibilityProperty.of(property, (newValue) -> newValue);
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [x] JavaDoc is added / changed for public methods.
- [x] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [x] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
Minor issues with new visibility functionality

## What is the new behavior?
Fixed issue when both Group and Setting have visibility defined. Group visibility used to overwrite setting visibility. Also prevent CategoryController from getting bigger and bigger when switching combobox content and PreferencesFxView is displayed as a node.

Fixes/Resolves/Closes #[Issue Number]

## Breaking Change:
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
