### PR TITLE
Add an API to check if any settings have been modified since last save

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -212,7 +212,7 @@ public class PreferencesFx {
    * Check if any changes are pending. Useful when manually saving settings.
    * @return true if there are unsaved changed.
    */
-  public boolean areSettingsPending() {
+  public boolean isContainingChanges() {
     return !preferencesFxModel.getHistory().getChanges().isEmpty();
   }
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -209,6 +209,14 @@ public class PreferencesFx {
   }
 
   /**
+   * Check if any changes are pending. Useful when manually saving settings.
+   * @return true if there are unsaved changed.
+   */
+  public boolean areSettingsPending() {
+    return !preferencesFxModel.getHistory().getChanges().isEmpty();
+  }
+
+  /**
    * Defines whether the table to debug the undo / redo history should be shown in a dialog when
    * pressing a key combination or not. <br> Pressing Ctrl + Shift + H (Windows) or CMD + Shift + H
    * (Mac) opens a dialog with the undo / redo history, shown in a table.


### PR DESCRIPTION
Use case: Settings are set to manually persist, but I want a listener to notify on unsaved changes.
This could also be used to change the title bar when there are unsaved changes.

## PR Checklist

- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [x] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
No way to check for pending changes

## What is the new behavior?
The ability to check for new changes