### PR TITLE
Don't call loadSettingValues twice on Init

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -47,7 +47,7 @@ public class PreferencesFxDialog extends DialogPane {
   /**
    * Initializes the {@link DialogPane} which shows the PreferencesFX window.
    *
-   * @param model             the model of PreferencesFX
+   * @param model             the model of PreferencesFX. Assumes settings are already loaded.
    * @param preferencesFxView the master view to be display in this {@link DialogPane}
    */
   public PreferencesFxDialog(PreferencesFxModel model, PreferencesFxView preferencesFxView) {
@@ -56,7 +56,6 @@ public class PreferencesFxDialog extends DialogPane {
     persistWindowState = model.isPersistWindowState();
     saveSettings = model.isSaveSettings();
     storageHandler = model.getStorageHandler();
-    model.loadSettingValues();
     layoutForm();
     setupDialogClose();
     loadLastWindowState();

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -47,7 +47,7 @@ public class PreferencesFxDialog extends DialogPane {
   /**
    * Initializes the {@link DialogPane} which shows the PreferencesFX window.
    *
-   * @param model             the model of PreferencesFX. Assumes settings are already loaded.
+   * @param model             the model of PreferencesFX
    * @param preferencesFxView the master view to be display in this {@link DialogPane}
    */
   public PreferencesFxDialog(PreferencesFxModel model, PreferencesFxView preferencesFxView) {
@@ -56,6 +56,7 @@ public class PreferencesFxDialog extends DialogPane {
     persistWindowState = model.isPersistWindowState();
     saveSettings = model.isSaveSettings();
     storageHandler = model.getStorageHandler();
+    model.loadSettingValues();
     layoutForm();
     setupDialogClose();
     loadLastWindowState();
@@ -64,6 +65,7 @@ public class PreferencesFxDialog extends DialogPane {
     if (model.getHistoryDebugState()) {
       setupDebugHistoryTable();
     }
+    model.getHistory().clear(false);  // Ensure history is initially empty
   }
 
   /**


### PR DESCRIPTION
Issue introduced in https://github.com/dlsc-software-consulting-gmbh/PreferencesFX/commit/8328b14c85059030b11fabff02214988f9e56217

<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [x] JavaDoc is added / changed for public methods.
- [ ] Tests for the changes are included.

## What is the current behavior?
#436

## What is the new behavior?
loadSettingValues is only called once on PreferencesFx.init()

Fixes #436.
