### PR TITLE
Create renderers lazily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>com.dlsc.formsfx</groupId>
                 <artifactId>formsfx-core</artifactId>
-                <version>11.5.0</version>
+                <version>11.6.0</version>
             </dependency>
 
             <dependency>

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/extended/ExtendedExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/extended/ExtendedExample.java
@@ -92,7 +92,7 @@ public class ExtendedExample extends StackPane {
   private SimpleListProperty<MyEnum> enumList =
       new SimpleListProperty<>(FXCollections.observableArrayList(Arrays.asList(MyEnum.values())));
   private SingleSelectionField<MyEnum> myEnumControl =
-      Field.ofSingleSelectionType(enumList, myEnumSettingValue).render(new SimpleComboBoxControl<>());
+      Field.ofSingleSelectionType(enumList, myEnumSettingValue).render(() -> new SimpleComboBoxControl<>());
 
   public ExtendedExample() {
     preferencesFx = createPreferences();
@@ -101,7 +101,7 @@ public class ExtendedExample extends StackPane {
 
   private IntegerField setupCustomControl() {
     return Field.ofIntegerType(customControlProperty).render(
-        new IntegerSliderControl(0, 42));
+            () -> new IntegerSliderControl(0, 42));
   }
 
   //  -------------- Demo --------------

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/i18n/InternationalizedExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/i18n/InternationalizedExample.java
@@ -85,7 +85,7 @@ public class InternationalizedExample extends StackPane {
 
   private IntegerField setupCustomControl() {
     return Field.ofIntegerType(customControlProperty).render(
-        new IntegerSliderControl(0, 42));
+            () -> new IntegerSliderControl(0, 42));
   }
 
   private PreferencesFx createPreferences() {

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/node/NodeExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/node/NodeExample.java
@@ -80,7 +80,7 @@ public class NodeExample extends StackPane {
 
   private IntegerField setupCustomControl() {
     return Field.ofIntegerType(customControlProperty).render(
-        new IntegerSliderControl(0, 42));
+            () -> new IntegerSliderControl(0, 42));
   }
 
   private PreferencesFx createPreferences() {

--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/standard/StandardExample.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/standard/StandardExample.java
@@ -72,7 +72,7 @@ public class StandardExample extends StackPane {
 
   StringProperty somePassword = new SimpleStringProperty("");
   PasswordField somePasswordControl = Field.ofPasswordType(somePassword).render(
-        new SimplePasswordControl());
+          () -> new SimplePasswordControl());
 
   public StandardExample() {
     preferencesFx = createPreferences();
@@ -81,7 +81,7 @@ public class StandardExample extends StackPane {
 
   private IntegerField setupCustomControl() {
     return Field.ofIntegerType(customControlProperty).render(
-        new IntegerSliderControl(0, 42));
+            () -> new IntegerSliderControl(0, 42));
   }
 
   private PreferencesFx createPreferences() {

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Setting.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/model/Setting.java
@@ -82,7 +82,7 @@ public class Setting<E extends Element, P extends Property> {
             description,
             Field.ofBooleanType(property)
                     .label(description)
-                    .render(ToggleControl.of(visibilityProperty)),
+                    .render(() -> ToggleControl.of(visibilityProperty)),
             property
     );
   }
@@ -111,7 +111,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofIntegerType(property)
             .label(description)
-            .render(SimpleIntegerControl.of(visibilityProperty)),
+            .render(() -> SimpleIntegerControl.of(visibilityProperty)),
         property);
   }
 
@@ -139,7 +139,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofDoubleType(property)
             .label(description)
-            .render(SimpleDoubleControl.of(visibilityProperty)),
+            .render(() -> SimpleDoubleControl.of(visibilityProperty)),
         property);
   }
 
@@ -174,7 +174,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofDoubleType(property)
             .label(description)
-            .render(DoubleSliderControl.of(min, max, precision, visibilityProperty)),
+            .render(() -> DoubleSliderControl.of(min, max, precision, visibilityProperty)),
         property);
   }
 
@@ -205,7 +205,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofIntegerType(property)
             .label(description)
-            .render(IntegerSliderControl.of(min, max, visibilityProperty)),
+            .render(() -> IntegerSliderControl.of(min, max, visibilityProperty)),
         property);
   }
 
@@ -233,7 +233,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofStringType(property)
             .label(description)
-            .render(SimpleTextControl.of(visibilityProperty)),
+            .render(() -> SimpleTextControl.of(visibilityProperty)),
         property);
   }
 
@@ -271,7 +271,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofSingleSelectionType(items, selection)
             .label(description)
-            .render(SimpleComboBoxControl.of(visibilityProperty)),
+            .render(() -> SimpleComboBoxControl.of(visibilityProperty)),
         selection);
   }
 
@@ -309,7 +309,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofSingleSelectionType(new SimpleListProperty<>(items), selection)
             .label(description)
-            .render(SimpleComboBoxControl.of(visibilityProperty)),
+            .render(() -> SimpleComboBoxControl.of(visibilityProperty)),
         selection);
   }
 
@@ -349,7 +349,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofMultiSelectionType(items, selections)
             .label(description)
-            .render(SimpleListViewControl.of(visibilityProperty)),
+            .render(() -> SimpleListViewControl.of(visibilityProperty)),
         selections);
   }
 
@@ -389,7 +389,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofMultiSelectionType(new SimpleListProperty<>(items), selections)
             .label(description)
-            .render(SimpleListViewControl.of(visibilityProperty)),
+            .render(() -> SimpleListViewControl.of(visibilityProperty)),
         selections);
   }
 
@@ -468,7 +468,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofStringType(stringProperty)
             .label(description)
-            .render(SimpleColorPickerControl.of(
+            .render(() -> SimpleColorPickerControl.of(
                 Objects.isNull(colorProperty.get()) ? Color.BLACK : colorProperty.get(), visibilityProperty)
             ),
         stringProperty
@@ -565,7 +565,7 @@ public class Setting<E extends Element, P extends Property> {
         description,
         Field.ofStringType(stringProperty)
             .label(description)
-            .render(SimpleChooserControl.of(buttonText, initialDirectory, directory, visibilityProperty)
+            .render(() -> SimpleChooserControl.of(buttonText, initialDirectory, directory, visibilityProperty)
             ),
         stringProperty
     );

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/util/StorageHandler.java
@@ -167,7 +167,4 @@ public interface StorageHandler {
    * @return true if successful, false if there was an exception.
    */
   boolean clearPreferences();
-
-  Preferences getPreferences();
-
 }

--- a/preferencesfx/src/main/java/module-info.java
+++ b/preferencesfx/src/main/java/module-info.java
@@ -6,8 +6,8 @@ module com.dlsc.preferencesfx {
     requires org.kordamp.ikonli.javafx;
     requires org.kordamp.ikonli.material;
 
-    requires java.prefs;
-    requires com.google.gson;
+    requires static java.prefs;
+    requires static com.google.gson;
     requires java.sql;
     requires org.controlsfx.controls;
     requires org.slf4j;


### PR DESCRIPTION
This is the matching PR for https://github.com/dlsc-software-consulting-gmbh/FormsFX/pull/65. The changes are straightforward and also backwards compatible. However they only compile when using the proper FormsFX commit/version.

One addition I included is also something that has been bugging me for a while and is about module dependencies. I use my own storage handler implementation and therefore don't use any of the java.prefs or gson modules, but as they are not declared static in the module-info, compilation will fail when they are not in the module path. This PR should fix that as well.