### PR TITLE
Correct asciidoctor-maven-plugin usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,8 +180,8 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <coderay-linenums-mode>table</coderay-linenums-mode>
                                 <imagesdir></imagesdir>
                                 <toc>left</toc>


### PR DESCRIPTION
According to the docs, the usage is not correct. I don't know when this changed, I suspect version 2.0.0.
This pom is using version 2.2.1.
https://docs.asciidoctor.org/maven-tools/latest/plugin/usage/