### PR TITLE
Add dependency on com.google.gson to the demo

### DIFF
--- a/preferencesfx-demo/src/main/java/module-info.java
+++ b/preferencesfx-demo/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module com.dlsc.preferencesfx.demo {
     requires org.apache.logging.log4j;
     requires org.apache.logging.log4j.core;
     requires org.apache.logging.log4j.slf4j;
+    requires com.google.gson;
 
     exports com.dlsc.preferencesfx.demo;
 


### PR DESCRIPTION
Due to commit https://github.com/dlsc-software-consulting-gmbh/PreferencesFX/commit/bc4f1e8095f6e06ba8ea4bef41f9907df84cae97 `com.google.gson` is no longer a forced dependency. However the example requires it.