### PR TITLE
Stop PreferencesFxFormRenderer from shrinking labels

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxFormRenderer.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxFormRenderer.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javafx.geometry.Insets;
-import javafx.scene.layout.GridPane;
+import javafx.scene.layout.*;
 
 /**
  * Renders a {@link Form} for a {@link Category} in PreferencesFX.
@@ -23,7 +23,7 @@ public class PreferencesFxFormRenderer extends GridPane implements ViewMixin {
    */
   public static final double SPACING = 5;
 
-  private Form form;
+  private final Form form;
   private List<PreferencesFxGroupRenderer> groups = new ArrayList<>();
 
   /**
@@ -59,5 +59,10 @@ public class PreferencesFxFormRenderer extends GridPane implements ViewMixin {
     // Outer Padding of Category Pane
     setPadding(new Insets(SPACING * 3));
     setHgap(SPACING * 3);
+
+    //This stops the left-most column from resizing
+    ColumnConstraints column1 = new ColumnConstraints();
+    column1.setMinWidth(Region.USE_PREF_SIZE);
+    getColumnConstraints().add(column1);
   }
 }


### PR DESCRIPTION
This change stops the right column from shrinking the left.
Hopefully the screenshots clarify the behaviour.

## PR Checklist

- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [ ] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlsc-software-consulting-gmbh/PreferencesFX/tree/master-11/preferencesfx-demo).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlsc-software-consulting-gmbh/PreferencesFX/tree/master-11/README.md).
- [ ] Tests for the changes are included.

## What is the current behavior?
![image](https://user-images.githubusercontent.com/5424257/235079344-9a7700eb-997b-4efa-8e26-e19851d694f1.png)


## What is the new behavior?
![image](https://user-images.githubusercontent.com/5424257/235079266-c154a4cb-3b91-46cb-828c-b33527202d13.png)