### PR TITLE
Fields migrate state private2protected

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/DoubleSliderControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/DoubleSliderControl.java
@@ -26,8 +26,8 @@ public class DoubleSliderControl extends SimpleControl<DoubleField, HBox> {
    * - slider is the control to change the value.
    * - node holds the control so that it can be styled properly.
    */
-  private Slider slider;
-  private Label valueLabel;
+  protected Slider slider;
+  protected Label valueLabel;
   private double min;
   private double max;
   private int precision;

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/IntegerSliderControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/IntegerSliderControl.java
@@ -23,9 +23,9 @@ public class IntegerSliderControl extends SimpleControl<IntegerField, HBox> {
    * - slider is the control to change the value.
    * - container holds the control so that it can be styled properly.
    */
-  private Label fieldLabel;
-  private Slider slider;
-  private Label valueLabel;
+  protected Label fieldLabel;
+  protected Slider slider;
+  protected Label valueLabel;
   private int min;
   private int max;
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleCheckBoxControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleCheckBoxControl.java
@@ -43,7 +43,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
    * - The checkboxes list contains all the checkboxes to display.
    * - The node is a VBox holding all node.
    */
-  private final List<CheckBox> checkboxes = new ArrayList<>();
+  public final List<CheckBox> checkboxes = new ArrayList<>();
 
   /**
    * Constructs a SimpleCheckBoxControl of {@link SimpleCheckBoxControl} type, with visibility condition.
@@ -137,7 +137,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
    * This method creates node and adds them to checkboxes and is
    * used when the itemsProperty on the field changes.
    */
-  private void createCheckboxes() {
+  public void createCheckboxes() {
     node.getChildren().clear();
     checkboxes.clear();
 
@@ -156,7 +156,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
   /**
    * Sets up bindings for all checkboxes.
    */
-  private void setupCheckboxBindings() {
+  public void setupCheckboxBindings() {
     for (CheckBox checkbox : checkboxes) {
       checkbox.disableProperty().bind(field.editableProperty().not());
     }
@@ -165,7 +165,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
   /**
    * Sets up event handlers for all checkboxes.
    */
-  private void setupCheckboxEventHandlers() {
+  public void setupCheckboxEventHandlers() {
     for (int i = 0; i < checkboxes.size(); i++) {
       final int j = i;
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleCheckBoxControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleCheckBoxControl.java
@@ -43,7 +43,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
    * - The checkboxes list contains all the checkboxes to display.
    * - The node is a VBox holding all node.
    */
-  public final List<CheckBox> checkboxes = new ArrayList<>();
+  protected final List<CheckBox> checkboxes = new ArrayList<>();
 
   /**
    * Constructs a SimpleCheckBoxControl of {@link SimpleCheckBoxControl} type, with visibility condition.
@@ -137,7 +137,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
    * This method creates node and adds them to checkboxes and is
    * used when the itemsProperty on the field changes.
    */
-  public void createCheckboxes() {
+  protected void createCheckboxes() {
     node.getChildren().clear();
     checkboxes.clear();
 
@@ -156,7 +156,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
   /**
    * Sets up bindings for all checkboxes.
    */
-  public void setupCheckboxBindings() {
+  protected void setupCheckboxBindings() {
     for (CheckBox checkbox : checkboxes) {
       checkbox.disableProperty().bind(field.editableProperty().not());
     }
@@ -165,7 +165,7 @@ public class SimpleCheckBoxControl<V> extends SimpleControl<MultiSelectionField<
   /**
    * Sets up event handlers for all checkboxes.
    */
-  public void setupCheckboxEventHandlers() {
+  protected void setupCheckboxEventHandlers() {
     for (int i = 0; i < checkboxes.size(); i++) {
       final int j = i;
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleChooserControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleChooserControl.java
@@ -55,10 +55,10 @@ public class SimpleChooserControl extends SimpleControl<StringField, StackPane> 
    * editableField allows users to modify the field's value. - The readOnlyLabel displays the
    * field's value if it is not editable.
    */
-  private TextField editableField;
-  private TextArea editableArea;
-  private Label readOnlyLabel;
-  private Label fieldLabel;
+  protected TextField editableField;
+  protected TextArea editableArea;
+  protected Label readOnlyLabel;
+  protected Label fieldLabel;
   private Button chooserButton = new Button();
   private HBox contentBox = new HBox();
   private String buttonText;

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleColorPickerControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleColorPickerControl.java
@@ -45,7 +45,7 @@ public class SimpleColorPickerControl extends SimpleControl<StringField, StackPa
   /**
    * - The colorPicker is the container that displays the node to select a color value.
    */
-  private ColorPicker colorPicker;
+  protected ColorPicker colorPicker;
   private Color initialValue;
   private Label fieldLabel;
 

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleComboBoxControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleComboBoxControl.java
@@ -47,9 +47,9 @@ public class SimpleComboBoxControl<V> extends SimpleControl<SingleSelectionField
    * - The readOnlyLabel is used to show the current selection in read only.
    * - The node is a StackPane to hold the field and read only label.
    */
-  private Label fieldLabel;
-  private ComboBox<V> comboBox;
-  private Label readOnlyLabel;
+  protected Label fieldLabel;
+  protected ComboBox<V> comboBox;
+  protected Label readOnlyLabel;
 
   /**
    * Constructs a SimpleComboBoxControl of {@link SimpleComboBoxControl} type, with visibility condition.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleListViewControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleListViewControl.java
@@ -44,12 +44,12 @@ public class SimpleListViewControl<V>
    * the field.
    * - The node is the container that displays list values.
    */
-  private Label fieldLabel;
+  protected Label fieldLabel;
 
   /**
    * The flag used for setting the selection properly.
    */
-  private boolean preventUpdate;
+  protected boolean preventUpdate;
 
   /**
    * Constructs a SimpleListViewControl of {@link SimpleListViewControl} type, with visibility condition.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleNumberControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleNumberControl.java
@@ -44,9 +44,9 @@ public abstract class SimpleNumberControl<F extends DataField, D extends Number>
    * - The editableSpinner is a Spinner for setting numerical values.
    * - The readOnlyLabel is the label to put over editableSpinner.
    */
-  private Label fieldLabel;
+  protected Label fieldLabel;
   protected Spinner<D> editableSpinner;
-  private Label readOnlyLabel;
+  protected Label readOnlyLabel;
 
   /**
    * {@inheritDoc}

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleRadioButtonControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleRadioButtonControl.java
@@ -46,10 +46,10 @@ public class SimpleRadioButtonControl<V> extends SimpleControl<SingleSelectionFi
    * - The toggleGroup defines the group for the radio buttons.
    * - The node is a VBox holding all radio buttons.
    */
-  private final List<RadioButton> radioButtons = new ArrayList<>();
-  private ToggleGroup toggleGroup;
+  protected final List<RadioButton> radioButtons = new ArrayList<>();
+  protected ToggleGroup toggleGroup;
 
-  private Label fieldLabel;
+  protected Label fieldLabel;
 
   /**
    * Constructs a SimpleRadioButtonControl of {@link SimpleRadioButtonControl} type, with visibility condition.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleTextControl.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/controls/SimpleTextControl.java
@@ -46,10 +46,10 @@ public class SimpleTextControl extends SimpleControl<StringField, StackPane> {
    * - The editableField allows users to modify the field's value.
    * - The readOnlyLabel displays the field's value if it is not editable.
    */
-  private TextField editableField;
-  private TextArea editableArea;
-  private Label readOnlyLabel;
-  private Label fieldLabel;
+  protected TextField editableField;
+  protected TextArea editableArea;
+  protected Label readOnlyLabel;
+  protected Label fieldLabel;
 
   /**
    * Constructs a SimpleTextControl of {@link SimpleTextControl} type, with visibility condition.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxFormRenderer.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxFormRenderer.java
@@ -23,8 +23,8 @@ public class PreferencesFxFormRenderer extends GridPane implements ViewMixin {
    */
   public static final double SPACING = 5;
 
-  private final Form form;
-  private List<PreferencesFxGroupRenderer> groups = new ArrayList<>();
+  protected final Form form;
+  protected List<PreferencesFxGroupRenderer> groups = new ArrayList<>();
 
   /**
    * This is the constructor to pass over data.

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroup.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroup.java
@@ -55,7 +55,7 @@ public class PreferencesFxGroup extends Group {
   /**
    * {@inheritDoc}
    */
-  private PreferencesFxGroup(Element... elements) {
+  protected PreferencesFxGroup(Element... elements) {
     super(elements);
 
     // Whenever the title's key changes, update the displayed value based

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroupRenderer.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/formsfx/view/renderer/PreferencesFxGroupRenderer.java
@@ -41,7 +41,7 @@ public class PreferencesFxGroupRenderer {
    *
    * @param preferencesGroup The PreferencesGroup which gets rendered.
    */
-  PreferencesFxGroupRenderer(PreferencesFxGroup preferencesGroup, GridPane grid) {
+  protected PreferencesFxGroupRenderer(PreferencesFxGroup preferencesGroup, GridPane grid) {
     this.preferencesGroup = preferencesGroup;
     this.grid = grid;
     preferencesGroup.setRenderer(this);


### PR DESCRIPTION
## PR Checklist

- [X] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).


## What is the current behavior?
PreferencesFX project has sources from FormsFX project for various controls. These fields have been made public in latest versions of same sources under FormsFX (https://github.com/dlsc-software-consulting-gmbh/FormsFX/pull/28/files#diff-417ae9bbd300ffa2be7fb7c286928a1dd4629cce71d656205fc12739e33796b9). Due to these fields still having Private modifiers within sources in PreferencesFX, its not possible to access those from derived classes in order to add listeners.

## What is the new behavior?
I have modified the private fields to protected to access those by derived  classes. This is in line with the latest changes in the same source files in latest revisions of FormsFX (https://github.com/dlsc-software-consulting-gmbh/FormsFX/pull/28/files#diff-417ae9bbd300ffa2be7fb7c286928a1dd4629cce71d656205fc12739e33796b9). This allows users to access them from derived 
 classes  in order to add listeners.

