### PR TITLE
fix: PreferencesFx.persistWindowState does not work

### DIFF
--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -35,7 +35,6 @@ public class PreferencesFxDialog extends DialogPane {
 
   private Dialog dialog = new Dialog();
   private StorageHandler storageHandler;
-  private boolean persistWindowState;
   private boolean saveSettings;
   private boolean modalityInitialized;
   private ButtonType closeWindowBtnType = ButtonType.CLOSE;
@@ -53,13 +52,11 @@ public class PreferencesFxDialog extends DialogPane {
   public PreferencesFxDialog(PreferencesFxModel model, PreferencesFxView preferencesFxView) {
     this.model = model;
     this.preferencesFxView = preferencesFxView;
-    persistWindowState = model.isPersistWindowState();
     saveSettings = model.isSaveSettings();
     storageHandler = model.getStorageHandler();
     model.loadSettingValues();
     layoutForm();
     setupDialogClose();
-    loadLastWindowState();
     setupButtons();
     setupValueChangedListeners();
     if (model.getHistoryDebugState()) {
@@ -84,6 +81,7 @@ public class PreferencesFxDialog extends DialogPane {
    *              the {@link PreferencesFxDialog}, as long as it is open.
    */
   public void show(boolean modal) {
+    loadLastWindowState();
     if (!modalityInitialized) {
       // only set modality once to avoid exception:
       // java.lang.IllegalStateException: Cannot set modality once stage has been set visible
@@ -133,7 +131,7 @@ public class PreferencesFxDialog extends DialogPane {
         model.discardChanges();
       } else {
         LOGGER.trace("Dialog - Close Button or 'x' was pressed");
-        if (persistWindowState) {
+        if (model.isPersistWindowState()) {
           saveWindowState();
         }
         model.saveSettings();
@@ -154,15 +152,19 @@ public class PreferencesFxDialog extends DialogPane {
    * Loads last saved size and position of the window.
    */
   private void loadLastWindowState() {
-    if (persistWindowState) {
+    if (model.isPersistWindowState()) {
       setPrefSize(storageHandler.loadWindowWidth(), storageHandler.loadWindowHeight());
-      getScene().getWindow().setX(storageHandler.loadWindowPosX());
-      getScene().getWindow().setY(storageHandler.loadWindowPosY());
       model.setDividerPosition(storageHandler.loadDividerPosition());
       model.setDisplayedCategory(model.loadSelectedCategory());
+      if (!modalityInitialized) {
+          getScene().getWindow().setX(storageHandler.loadWindowPosX());
+          getScene().getWindow().setY(storageHandler.loadWindowPosY());
+      }
     } else {
       setPrefSize(Constants.DEFAULT_PREFERENCES_WIDTH, Constants.DEFAULT_PREFERENCES_HEIGHT);
-      getScene().getWindow().centerOnScreen();
+      if (!modalityInitialized) {
+          getScene().getWindow().centerOnScreen();
+      }
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
To help us review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [ ] JavaDoc is added / changed for public methods.
- [ ] An example of the new feature is added to the [demos](https://github.com/dlsc-software-consulting-gmbh/PreferencesFX/tree/master-11/preferencesfx-demo).
- [ ] Documentation of the feature is included in the [README](https://github.com/dlsc-software-consulting-gmbh/PreferencesFX/tree/master-11/README.md).
- [x] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are changing, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes -->

Fixes/Resolves/Closes #453

## Breaking Change:
<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->
