### PR TITLE
Add i18n support for dialog buttons text

### DIFF
--- a/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/dialog_i18n/AppStarter.java
+++ b/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx/demo/dialog_i18n/AppStarter.java
@@ -1,0 +1,45 @@
+package com.dlsc.preferencesfx.demo.dialog_i18n;
+
+import com.dlsc.preferencesfx.PreferencesFx;
+import com.dlsc.preferencesfx.model.Category;
+import com.dlsc.preferencesfx.model.Setting;
+import javafx.application.Application;
+import javafx.beans.property.ListProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleListProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.geometry.NodeOrientation;
+import javafx.scene.control.Dialog;
+import javafx.stage.Stage;
+
+import java.util.Arrays;
+
+/**
+ * A demo using dialog mode, because embedded mode doesn't show dialog buttons.
+ */
+public class AppStarter extends Application {
+
+    public static void main(String [] args) {
+        launch(args);
+    }
+
+    @Override
+    public void start(Stage stage) throws Exception {
+        ListProperty<String> themeItems = new SimpleListProperty<>(
+                FXCollections.observableArrayList(Arrays.asList("Light theme", "Dark theme"))
+        );
+        ObjectProperty<String> themeProperty = new SimpleObjectProperty<>();
+
+        Category general = Category.of("إعدادات عامة",
+                Setting.of("المظهر", themeItems, themeProperty)
+        );
+        PreferencesFx preferencesFx = PreferencesFx.of(this.getClass(), general);
+        preferencesFx.getView().setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+
+        preferencesFx.setDialogButtonsText("إغلاق", "موافق","تطبيق","إلغاء");
+        preferencesFx.show();
+        Stage preferencesStage = (Stage) preferencesFx.getView().getScene().getWindow();
+        preferencesStage.setMaximized(true);
+    }
+}

--- a/preferencesfx-demo/src/main/java/module-info.java
+++ b/preferencesfx-demo/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module com.dlsc.preferencesfx.demo {
     requires com.google.gson;
 
     exports com.dlsc.preferencesfx.demo;
+    exports  com.dlsc.preferencesfx.demo.dialog_i18n;
 
     opens com.dlsc.preferencesfx.demo;
     opens com.dlsc.preferencesfx.demo.extended;

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/PreferencesFx.java
@@ -21,9 +21,12 @@ import com.dlsc.preferencesfx.view.UndoRedoBox;
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
 import javafx.event.EventType;
+import javafx.scene.control.ButtonType;
 import javafx.scene.image.Image;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ResourceBundle;
 
 /**
  * Represents the main PreferencesFX class.
@@ -318,12 +321,42 @@ public class PreferencesFx {
     preferencesFxDialog.setDialogIcon(image);
     return this;
   }
-  
+
   /**
-   * Return the stylesheets of the PreferenceFxDialog.
+   * Sets the text of the dialog buttons using a ResourceBundle.
    *
-   * @return the stylesheets List of the PreferenceFxDialog
+   * ResourceBundle keys:
+   * <ul>
+   *   <li><b>button.close</b>  - text for the Close button</li>
+   *   <li><b>button.ok</b>     - text for the OK button</li>
+   *   <li><b>button.apply</b>  - text for the Apply button</li>
+   *   <li><b>button.cancel</b> - text for the Cancel button</li>
+   * </ul>
    */
+  public PreferencesFx setDialogButtonsText(ResourceBundle bundle) {
+    preferencesFxDialog.setDialogButtonsText(bundle);
+    return this;
+  }
+
+  /**
+   * Set the text language on the dialog buttons to the language of your choice.
+   * You can also do so using {@link #setDialogButtonsText(java.util.ResourceBundle) setDialogButtonsText(ResourceBundle)}.
+   *
+   * @param close  text to show on the "close" button
+   * @param ok     text to show on the "ok" button
+   * @param apply  text to show on the "apply" button
+   * @param cancel text to show on the "cancel" button
+   */
+  public PreferencesFx setDialogButtonsText(String close, String ok, String apply, String cancel) {
+    preferencesFxDialog.setDialogButtonsText(close, ok, apply, cancel);
+    return this;
+  }
+
+    /**
+     * Return the stylesheets of the PreferenceFxDialog.
+     *
+     * @return the stylesheets List of the PreferenceFxDialog
+     */
   public ObservableList<String> getStylesheets() {
     return preferencesFxDialog.getStylesheets();
   }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -7,6 +7,7 @@ import com.dlsc.preferencesfx.util.Constants;
 import com.dlsc.preferencesfx.util.StorageHandler;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.DialogPane;
@@ -19,6 +20,8 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ResourceBundle;
 
 /**
  * Represents the dialog which is used to show the PreferencesFX window.
@@ -249,4 +252,57 @@ public class PreferencesFxDialog extends DialogPane {
   public void setDialogIcon(Image image) {
     ((Stage) dialog.getDialogPane().getScene().getWindow()).getIcons().add(image);
   }
+
+  /**
+   * Set the text language on the dialog buttons to the language of your choice.
+   * You can also do so using {@link #setDialogButtonsText(java.util.ResourceBundle) setDialogButtonsText(ResourceBundle)}.
+   *
+   * @param close  text to show on the "close" button
+   * @param ok     text to show on the "ok" button
+   * @param apply  text to show on the "apply" button
+   * @param cancel text to show on the "cancel" button
+   */
+  public void setDialogButtonsText(String close, String ok, String apply, String cancel) {
+    closeWindowBtnType = new ButtonType(close, ButtonType.CLOSE.getButtonData());
+    okBtnType = new ButtonType(ok, ButtonType.OK.getButtonData());
+    applyBtnType = new ButtonType(apply, ButtonType.APPLY.getButtonData());
+    cancelBtnType = new ButtonType(cancel, ButtonType.CANCEL.getButtonData());
+    setupButtons();
+  }
+
+  /**
+   * Sets the text of the dialog buttons using a ResourceBundle.
+   *
+   * ResourceBundle keys:
+   * <ul>
+   *   <li><b>button.close</b>  - text for the Close button</li>
+   *   <li><b>button.ok</b>     - text for the OK button</li>
+   *   <li><b>button.apply</b>  - text for the Apply button</li>
+   *   <li><b>button.cancel</b> - text for the Cancel button</li>
+   * </ul>
+   */
+  public void setDialogButtonsText(ResourceBundle bundle) {
+    closeWindowBtnType = new ButtonType(
+            bundle.getString("button.close"),
+            ButtonType.CLOSE.getButtonData()
+    );
+
+    okBtnType = new ButtonType(
+            bundle.getString("button.ok"),
+            ButtonType.OK.getButtonData()
+    );
+
+    applyBtnType = new ButtonType(
+            bundle.getString("button.apply"),
+            ButtonType.APPLY.getButtonData()
+    );
+
+    cancelBtnType = new ButtonType(
+            bundle.getString("button.cancel"),
+            ButtonType.CANCEL.getButtonData()
+    );
+
+    setupButtons();
+  }
+
 }

--- a/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
+++ b/preferencesfx/src/main/java/com/dlsc/preferencesfx/view/PreferencesFxDialog.java
@@ -267,9 +267,17 @@ public class PreferencesFxDialog extends DialogPane {
     okBtnType = new ButtonType(ok, ButtonType.OK.getButtonData());
     applyBtnType = new ButtonType(apply, ButtonType.APPLY.getButtonData());
     cancelBtnType = new ButtonType(cancel, ButtonType.CANCEL.getButtonData());
+
+    getButtonTypes().clear();
+
+    if (model.isInstantPersistent()) {
+      getButtonTypes().addAll(closeWindowBtnType, cancelBtnType);
+    } else {
+      getButtonTypes().addAll(cancelBtnType, applyBtnType, okBtnType);
+    }
+
     setupButtons();
   }
-
   /**
    * Sets the text of the dialog buttons using a ResourceBundle.
    *
@@ -301,6 +309,14 @@ public class PreferencesFxDialog extends DialogPane {
             bundle.getString("button.cancel"),
             ButtonType.CANCEL.getButtonData()
     );
+
+    getButtonTypes().clear();
+
+    if (model.isInstantPersistent()) {
+      getButtonTypes().addAll(closeWindowBtnType, cancelBtnType);
+    } else {
+      getButtonTypes().addAll(cancelBtnType, applyBtnType, okBtnType);
+    }
 
     setupButtons();
   }


### PR DESCRIPTION

## What is the current behavior?
<!-- Please describe the current behavior that you are changing, or link to a relevant issue. -->
Dialog buttons' text language cannot be changed when Locale/ResourceBundle is changed.

## What is the new behavior?
<!-- Describe the changes -->
Added the possibility to change the text on the dialog's buttons, which are not affected by ResourceBundle setting used on the rest of the dialog. 

Note: Had to use a separate main class for the demo, because the dialog button do not show in embedded mode. 